### PR TITLE
diff-tables script

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,5 +75,3 @@ $ diff-tables us-east-1/primary eu-west-2/new-replica --backfill --repair
 # Perform one segment of a parallel scan
 $ diff-tables us-east-1/primar eu-west-2/replica --repair --segment 0 --segments 10
 ```
-
-To repa

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [dynamodb-replicator](https://github.com/mapbox/dynamodb-replicator) consumes a Kinesis stream of DynamoDB changes (keys-only) and writes them to a replica DynamoDB table. dynamodb-replicator is compatible with the upcoming DynamoDB streams ([in preview](http://dynamodb-preview.s3-website-us-west-2.amazonaws.com/docs/streams-dg/About.html)) as well as [dyno](https://github.com/mapbox/dyno) with Kinesis ([available already](https://github.com/mapbox/dyno#multi--kinesisconfig)).
 
+[dynamodb-replicator](https://github.com/mapbox/dynamodb-replicator) also provides a `diff-tables` script to compare two tables and bring them in sync with one another.
+
 ### Features
 
 - Primary-Replica replication between DynamoDB tables in different regions
@@ -14,7 +16,7 @@
 
 Replication involves many moving parts, of which dynamodb-replicator is only one. Please read [DESIGN.md](https://github.com/mapbox/dynamodb-replicator/blob/master/DESIGN.md) for an in-depth explaination.
 
-### Usage
+### Replicator usage
 
 dynamodb-replicator is designed to be used along with the [Node Kinesis Client Library](https://github.com/evansolomon/nodejs-kinesis-client-library) in your own project:
 
@@ -46,3 +48,32 @@ launch-kinesis-cluster \
   --table kinesis-cluster-replica \
   --stream kinesis-stream-name
 ```
+
+### diff-tables usage
+
+```
+$ npm install -g dynamodb-replicator
+$ diff-tables --help
+
+Usage: diff-tables primary-region/primary-table replica-region/replica-table
+
+Options:
+  --repair     perform actions to fix discrepancies in the replica table
+  --segment    segment identifier (0-based)
+  --segments   total number of segments
+  --backfill   only scan primary table and write to replica
+
+# log information about discrepancies between the two tables
+$ diff-tables us-east-1/primary eu-west-2/replica
+
+# repair the replica to match the primary
+$ diff-tables us-east-1/primary eu-west-2/replica --repair
+
+# Only backfill the replica. Useful for starting a new replica
+$ diff-tables us-east-1/primary eu-west-2/new-replica --backfill --repair
+
+# Perform one segment of a parallel scan
+$ diff-tables us-east-1/primar eu-west-2/replica --repair --segment 0 --segments 10
+```
+
+To repa

--- a/bin/diff-tables.js
+++ b/bin/diff-tables.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 var diff = require('../diff');
 var split = require('split');
 var queue = require('queue-async');
+var fastlog = require('fastlog');
 
 var config = {
     primary: {
@@ -19,7 +20,7 @@ var config = {
 var args = require('minimist')(process.argv.slice(2));
 
 config.repair = !!args.repair;
-config.parallel = Number(args.parallel);
+config.log = fastlog('diff-tables', 'info');
 
 if (args.primary) {
     args.primary = args.primary.split('/');
@@ -33,20 +34,9 @@ if (args.replica) {
     config.replica.table = args.replica[1];
 }
 
-diff(config, function(err, results) {
+diff(config, function(err, discrepancies) {
     if (err) {
-        console.error(err);
+        config.log.error(err);
         process.exit(1);
     }
-
-    console.log('Errors:');
-    console.log(fs.readFileSync(results.errors, 'utf8'));
-    console.log('Missing records:');
-    console.log(fs.readFileSync(results.missing, 'utf8'));
-    console.log('Different records:');
-    console.log(fs.readFileSync(results.different, 'utf8'));
-
-    var summary = 'Found ' + results.discrepancies + ' discrepancies';
-    if (args.repair) summary = summary + ' and repaired them';
-    console.log(summary);
 });

--- a/bin/diff-tables.js
+++ b/bin/diff-tables.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+var fs = require('fs');
+var diff = require('../diff');
+var split = require('split');
+var queue = require('queue-async');
+
+var config = {
+    primary: {
+        region: process.env.PrimaryRegion,
+        table: process.env.PrimaryTable
+    },
+    replica: {
+        region: process.env.ReplicaRegion,
+        table: process.env.ReplicaTable
+    }
+};
+
+var args = require('minimist')(process.argv.slice(2));
+
+config.repair = !!args.repair;
+config.parallel = Number(args.parallel);
+
+if (args.primary) {
+    args.primary = args.primary.split('/');
+    config.primary.region = args.primary[0];
+    config.primary.table = args.primary[1];
+}
+
+if (args.replica) {
+    args.replica = args.replica.split('/');
+    config.replica.region = args.replica[0];
+    config.replica.table = args.replica[1];
+}
+
+diff(config, function(err, results) {
+    if (err) {
+        console.error(err);
+        process.exit(1);
+    }
+
+    console.log('Errors:');
+    console.log(fs.readFileSync(results.errors, 'utf8'));
+    console.log('Missing records:');
+    console.log(fs.readFileSync(results.missing, 'utf8'));
+    console.log('Different records:');
+    console.log(fs.readFileSync(results.different, 'utf8'));
+
+    var summary = 'Found ' + results.discrepancies + ' discrepancies';
+    if (args.repair) summary = summary + ' and repaired them';
+    console.log(summary);
+});

--- a/diff.js
+++ b/diff.js
@@ -1,0 +1,76 @@
+var fs = require('fs');
+var _ = require('underscore');
+var queue = require('queue-async');
+var es = require('event-stream');
+var Dyno = require('dyno');
+var path = require('path');
+var os = require('os');
+var crypto = require('crypto');
+
+function tmpfile() {
+    var filename = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));
+    var stream = fs.createWriteStream(filename);
+    stream.filename = filename;
+    return stream;
+}
+
+module.exports = function(config, callback) {
+    var primary = Dyno(config.primary);
+    var replica = Dyno(config.replica);
+
+    var q = queue(config.parallel || 3);
+    var errors = tmpfile();
+    var missing = tmpfile();
+    var different = tmpfile();
+    var discrepancies = 0;
+
+    primary.describeTable(function(err, description) {
+        if (err) return callback(err);
+
+        var keySchema = _(description.Table.KeySchema).pluck('AttributeName');
+
+        primary.scan()
+            .pipe(es.map(function(record, cb) {
+                var key = keySchema.reduce(function(key, attribute) {
+                    key[attribute] = record[attribute];
+                    return key;
+                }, {});
+
+                replica.getItem(key, function(err, resp) {
+                    if (err) {
+                        errors.write(err + '\n');
+                    } else if (!resp) {
+                        discrepancies++;
+                        missing.write(JSON.stringify(key) + '\n');
+                        if (config.repair) q.defer(replica.putItem, record);
+                    } else if (!_.isEqual(record, resp)) {
+                        discrepancies++;
+                        different.write(JSON.stringify(key) + '\n');
+                        if (config.repair) q.defer(replica.putItem, record);
+                    }
+
+                    cb();
+                });
+            }))
+            .on('error', callback)
+            .on('end', function() {
+                [errors, missing, different].forEach(function(output) {
+                    q.defer(function(next) {
+                        output.on('finish', next);
+                        output.end();
+                    });
+                });
+
+                q.awaitAll(function(err) {
+                    if (err) return callback(err);
+
+                    callback(null, {
+                        errors: errors.filename,
+                        missing: missing.filename,
+                        different: different.filename,
+                        discrepancies: discrepancies
+                    });
+                });
+            });
+    });
+};

--- a/diff.js
+++ b/diff.js
@@ -1,76 +1,89 @@
-var fs = require('fs');
 var _ = require('underscore');
 var queue = require('queue-async');
-var es = require('event-stream');
 var Dyno = require('dyno');
-var path = require('path');
-var os = require('os');
-var crypto = require('crypto');
+var stream = require('stream');
 
-function tmpfile() {
-    var filename = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));
-    var stream = fs.createWriteStream(filename);
-    stream.filename = filename;
-    return stream;
-}
-
-module.exports = function(config, callback) {
+module.exports = function(config, done) {
     var primary = Dyno(config.primary);
     var replica = Dyno(config.replica);
+    primary.name = 'primary';
+    replica.name = 'replica';
 
-    var q = queue(config.parallel || 3);
-    var errors = tmpfile();
-    var missing = tmpfile();
-    var different = tmpfile();
+    var log = config.log || function() {};
+
     var discrepancies = 0;
+
+    function Compare(read, write, keySchema, deleteMissing) {
+        var writable = new stream.Writable({ objectMode: true });
+
+        writable.discrepancies = 0;
+
+        writable._write = function(record, enc, callback) {
+            var key = keySchema.reduce(function(key, attribute) {
+                key[attribute] = record[attribute];
+                return key;
+            }, {});
+
+            read.getItem(key, function(err, item) {
+                if (err) return writable.emit('error', err);
+
+                if (!item) {
+                    writable.discrepancies++;
+                    log('[missing in %s] %j', read.name, key);
+                    if (!config.repair) return callback();
+                    if (deleteMissing) return write.deleteItem(key, callback);
+                    return write.putItem(record, callback);
+                }
+
+                if (!_.isEqual(record, item)) {
+                    writable.discrepancies++;
+                    log('[different in %s] %j', read.name, key);
+                    if (!config.repair) return callback();
+                    return write.putItem(record, callback);
+                }
+
+                callback();
+            });
+        };
+
+        return writable;
+    }
 
     primary.describeTable(function(err, description) {
         if (err) return callback(err);
-
         var keySchema = _(description.Table.KeySchema).pluck('AttributeName');
+        scanPrimary(keySchema);
+    });
+
+    function scanPrimary(keySchema) {
+        var compare = Compare(replica, replica, keySchema, false);
+
+        log('Scanning primary table and comparing to replica');
 
         primary.scan()
-            .pipe(es.map(function(record, cb) {
-                var key = keySchema.reduce(function(key, attribute) {
-                    key[attribute] = record[attribute];
-                    return key;
-                }, {});
-
-                replica.getItem(key, function(err, resp) {
-                    if (err) {
-                        errors.write(err + '\n');
-                    } else if (!resp) {
-                        discrepancies++;
-                        missing.write(JSON.stringify(key) + '\n');
-                        if (config.repair) q.defer(replica.putItem, record);
-                    } else if (!_.isEqual(record, resp)) {
-                        discrepancies++;
-                        different.write(JSON.stringify(key) + '\n');
-                        if (config.repair) q.defer(replica.putItem, record);
-                    }
-
-                    cb();
-                });
-            }))
-            .on('error', callback)
-            .on('end', function() {
-                [errors, missing, different].forEach(function(output) {
-                    q.defer(function(next) {
-                        output.on('finish', next);
-                        output.end();
-                    });
-                });
-
-                q.awaitAll(function(err) {
-                    if (err) return callback(err);
-
-                    callback(null, {
-                        errors: errors.filename,
-                        missing: missing.filename,
-                        different: different.filename,
-                        discrepancies: discrepancies
-                    });
-                });
+            .on('error', done)
+            .pipe(compare)
+            .on('error', done)
+            .on('finish', function() {
+                discrepancies += compare.discrepancies;
+                log('[discrepancies] Scanning primary: %s', compare.discrepancies);
+                scanReplica(keySchema);
             });
-    });
+    }
+
+    function scanReplica(keySchema) {
+        var compare = Compare(primary, replica, keySchema, true);
+
+        log('Scanning replica table and comparing to primary');
+
+        replica.scan()
+            .on('error', done)
+            .pipe(compare)
+            .on('error', done)
+            .on('finish', function() {
+                discrepancies += compare.discrepancies;
+                log('[discrepancies] Scanning replica: %s', compare.discrepancies);
+                done(null, discrepancies);
+            });
+    }
 };

--- a/diff.js
+++ b/diff.js
@@ -9,7 +9,7 @@ module.exports = function(config, done) {
     primary.name = 'primary';
     replica.name = 'replica';
 
-    var log = config.log || function() {};
+    var log = config.log || console.log;
 
     var discrepancies = 0;
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "diff-tables": "bin/diff-tables.js",
     "test": "tap test/*.test.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/mapbox/dynamodb-replicator",
   "dependencies": {
-    "dyno": "^0.9.0",
+    "dyno": "^0.11.0",
     "event-stream": "^3.2.2",
     "fastlog": "^1.0.0",
     "logger": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test/index.js"
+    "test": "tap test/*.test.js"
   },
   "repository": {
     "type": "git",
@@ -17,10 +17,14 @@
   },
   "homepage": "https://github.com/mapbox/dynamodb-replicator",
   "dependencies": {
+    "dyno": "^0.9.0",
+    "event-stream": "^3.2.2",
     "fastlog": "^1.0.0",
     "logger": "0.0.1",
+    "minimist": "^1.1.0",
     "queue-async": "^1.0.7",
-    "dyno": "^0.9.0"
+    "split": "^0.3.3",
+    "underscore": "^1.8.2"
   },
   "devDependencies": {
     "dynalite": "^0.5.2",

--- a/test/diff.test.js
+++ b/test/diff.test.js
@@ -1,0 +1,69 @@
+var test = require('tap').test;
+var setup = require('./setup')(process.env.LIVE_TEST);
+var diff = require('../diff');
+var _ = require('underscore');
+var config = _(setup.config).clone();
+var fs = require('fs');
+var exec = require('child_process').exec;
+
+var opts = { timeout: 600000 };
+
+test('setup', opts, setup.setup);
+
+test('diff: without repairs', opts, function(assert) {
+    diff(config, function(err, results) {
+        assert.ifError(err, 'diff tables');
+        if (err) return assert.end();
+
+        assert.equal(results.discrepancies, 2, 'two discrepacies');
+
+        var errors = fs.readFileSync(results.errors, 'utf8');
+        var missing = fs.readFileSync(results.missing, 'utf8');
+        var different = fs.readFileSync(results.different, 'utf8');
+
+        assert.notOk(errors, 'no errors logged');
+        assert.equal(missing, '{"hash":"hash1","range":"range1"}\n', 'expected missing record');
+        assert.equal(different, '{"hash":"hash1","range":"range2"}\n', 'expected different record');
+
+        assert.end();
+    });
+});
+
+test('diff: with repairs', opts, function(assert) {
+    config.repair = true;
+
+    diff(config, function(err, results) {
+        assert.ifError(err, 'diff tables');
+        if (err) return assert.end();
+
+        assert.equal(results.discrepancies, 2, 'two discrepacies');
+
+        var errors = fs.readFileSync(results.errors, 'utf8');
+        var missing = fs.readFileSync(results.missing, 'utf8');
+        var different = fs.readFileSync(results.different, 'utf8');
+
+        assert.notOk(errors, 'no errors logged');
+        assert.equal(missing, '{"hash":"hash1","range":"range1"}\n', 'expected missing record');
+        assert.equal(different, '{"hash":"hash1","range":"range2"}\n', 'expected different record');
+
+        config.repair = false;
+        diff(config, function(err, results) {
+            assert.ifError(err, 'diff tables');
+            if (err) return assert.end();
+
+            assert.equal(results.discrepancies, 0, 'no discrepacies');
+
+            var errors = fs.readFileSync(results.errors, 'utf8');
+            var missing = fs.readFileSync(results.missing, 'utf8');
+            var different = fs.readFileSync(results.different, 'utf8');
+
+            assert.notOk(errors, 'no errors logged');
+            assert.notOk(missing, 'no missing logged');
+            assert.notOk(different, 'no different logged');
+
+            assert.end();
+        });
+    });
+});
+
+test('teardown', opts, setup.teardown);

--- a/test/diff.test.js
+++ b/test/diff.test.js
@@ -2,19 +2,21 @@ var test = require('tap').test;
 var setup = require('./setup')(process.env.LIVE_TEST);
 var diff = require('../diff');
 var _ = require('underscore');
-var config = _(setup.config).clone();
 var fs = require('fs');
 var util = require('util');
 
 var opts = { timeout: 600000 };
 
+var config = _(setup.config).clone();
+config.log = function() {
+    config.log.messages.push(util.format.apply(this, arguments));
+};
+config.log.messages = [];
+
 test('setup', opts, setup.setup);
 
 test('diff: without repairs', opts, function(assert) {
     config.repair = false;
-    config.log = function() {
-        config.log.messages.push(util.format.apply(this, arguments));
-    };
     config.log.messages = [];
 
     diff(config, function(err, discrepancies) {
@@ -62,9 +64,6 @@ test('diff: without repairs', opts, function(assert) {
 
 test('diff: with repairs', opts, function(assert) {
     config.repair = true;
-    config.log = function() {
-        config.log.messages.push(util.format.apply(this, arguments));
-    };
     config.log.messages = [];
 
     diff(config, function(err, discrepancies) {
@@ -98,6 +97,64 @@ test('diff: with repairs', opts, function(assert) {
                 '[discrepancies] Scanning replica: 0'
             ]);
 
+            assert.end();
+        });
+    });
+});
+test('teardown', setup.teardown);
+
+test('setup', opts, setup.setup);
+test('diff: backfill', opts, function(assert) {
+    config.repair = true;
+    config.backfill = true;
+    config.log.messages = [];
+
+    diff(config, function(err, discrepancies) {
+        assert.ifError(err, 'diff tables');
+        if (err) return assert.end();
+
+        assert.equal(discrepancies, 2, 'two discrepacies');
+        assert.deepEqual(config.log.messages, [
+            'Scanning primary table and comparing to replica',
+            '[missing in replica] {"hash":"hash1","range":"range1"}',
+            '[different in replica] {"hash":"hash1","range":"range2"}',
+            '[discrepancies] Scanning primary: 2'
+        ]);
+
+        config.repair = false;
+        config.log.messages = [];
+        diff(config, function(err, discrepancies) {
+            assert.ifError(err, 'diff tables');
+            if (err) return assert.end();
+
+            assert.equal(discrepancies, 0, 'no discrepacies on second comparison');
+            assert.deepEqual(config.log.messages, [
+                'Scanning primary table and comparing to replica',
+                '[discrepancies] Scanning primary: 0'
+            ]);
+
+            assert.end();
+        });
+    });
+});
+test('teardown', setup.teardown);
+
+test('setup', opts, setup.setup);
+test('diff: parallel', opts, function(assert) {
+    config.repair = false;
+    config.backfill = false;
+    config.segment = 0;
+    config.segments = 10;
+    config.log.messages = [];
+
+    setup.differentItemsPlease(1000, function(err) {
+        if (err) throw err;
+
+        diff(config, function(err, discrepancies) {
+            assert.ifError(err, 'diff tables');
+            if (err) return assert.end();
+
+            assert.ok(discrepancies < 1000, 'scanned partial table');
             assert.end();
         });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,7 @@
 var test = require('tap').test,
     fs = require('fs'),
     queue = require('queue-async');
-var s = require('./setup');
+var s = require('./setup')();
 var config = s.config;
 var dynos = s.dynos;
 


### PR DESCRIPTION
Add `diff.js`: exports a function that
- checks the primary table for its key schema
- scans the primary table
- makes individual `getItem` requests in the replica for each primary record
- [optionally] repairs discrepancies in the replica table
- reports the number of discrepancies found, stashes missing / different record keys in files

Add a `bin/diff-tables.js` executable that calls this function:

```sh
$ diff-tables --primary us-east-1/primary-table --replica eu-west-1/replica-table --repair
```

Adjusts `test/setup.js` such that you can run tests live by sending it a truthy value. For example in `diff.test.js`:
```js
var setup = require('./setup')(process.env.LIVE_TEST);
```

This means you could run the diff-script tests against live dynamodb via:
```sh
$ LIVE_TEST=1 node test/diff.test.js
```

### Thoughts

If `dyno.scan()` returns records sorted on the table's hash key, we could feasibly aggregate scan results by hash key, then `query` the replica table for all the records with the specified hash value. This might reduce read load on the replica table.

cc @freenerd @mick @willwhite 