### PR TITLE
Dual-scan diff-tables

### DIFF
--- a/bin/diff-tables.js
+++ b/bin/diff-tables.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+var fs = require('fs');
+var diff = require('../diff');
+var split = require('split');
+var queue = require('queue-async');
+
+var config = {
+    primary: {
+        region: process.env.PrimaryRegion,
+        table: process.env.PrimaryTable
+    },
+    replica: {
+        region: process.env.ReplicaRegion,
+        table: process.env.ReplicaTable
+    }
+};
+
+var args = require('minimist')(process.argv.slice(2));
+
+config.repair = !!args.repair;
+config.parallel = Number(args.parallel);
+
+if (args.primary) {
+    args.primary = args.primary.split('/');
+    config.primary.region = args.primary[0];
+    config.primary.table = args.primary[1];
+}
+
+if (args.replica) {
+    args.replica = args.replica.split('/');
+    config.replica.region = args.replica[0];
+    config.replica.table = args.replica[1];
+}
+
+diff(config, function(err, results) {
+    if (err) {
+        console.error(err);
+        process.exit(1);
+    }
+
+    console.log('Errors:');
+    console.log(fs.readFileSync(results.errors, 'utf8'));
+    console.log('Missing records:');
+    console.log(fs.readFileSync(results.missing, 'utf8'));
+    console.log('Different records:');
+    console.log(fs.readFileSync(results.different, 'utf8'));
+
+    var summary = 'Found ' + results.discrepancies + ' discrepancies';
+    if (args.repair) summary = summary + ' and repaired them';
+    console.log(summary);
+});

--- a/diff.js
+++ b/diff.js
@@ -1,0 +1,234 @@
+var fs = require('fs');
+var _ = require('underscore');
+var queue = require('queue-async');
+var path = require('path');
+var os = require('os');
+var crypto = require('crypto');
+var AWS = require('aws-sdk');
+
+module.exports = run;
+
+function tmpfile() {
+    var filename = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));
+    var stream = fs.createWriteStream(filename);
+    stream.filename = filename;
+    return stream;
+}
+
+function extractKey(item, keyAttributes) {
+    var key = keyAttributes.reduce(function(key, attr) {
+        key[attr] = item[attr];
+        return key;
+    }, {});
+
+    return JSON.stringify(key);
+}
+
+function Scanner(dynamo, table, keyAttributes) {
+    var key;
+    var done = false;
+
+    var scanner = {};
+
+    scanner.read = function(callback) {
+        // Makes a single scan, indexes the results by stringified key
+        if (done) return callback();
+
+        var params = { TableName: table };
+        if (key) params.ExclusiveStartKey = key;
+
+        dynamo.scan(params, function(err, data) {
+            if (err) return callback(err);
+
+            var results = data.Items.reduce(function(results, item) {
+                var key = extractKey(item, keyAttributes);
+                results[key] = item;
+                return results;
+            }, {});
+
+            if (!data.LastEvaluatedKey) done = true;
+            key = data.LastEvaluatedKey;
+
+            callback(null, results);
+        });
+    };
+
+    return scanner;
+}
+
+function run(config, callback) {
+    var primaryDynamo = new AWS.DynamoDB({
+        region: config.primary.region,
+        accessKeyId: config.primary.accessKeyId,
+        secretAccessKey: config.primary.secretAccessKey,
+        sessionToken: config.primary.sessionToken,
+        endpoint: config.primary.endpoint
+    });
+
+    var replicaDynamo = new AWS.DynamoDB({
+        region: config.replica.region,
+        accessKeyId: config.replica.accessKeyId,
+        secretAccessKey: config.replica.secretAccessKey,
+        sessionToken: config.replica.sessionToken,
+        endpoint: config.replica.endpoint
+    });
+
+    var primaryTable = config.primary.table;
+    var replicaTable = config.replica.table;
+
+    // Setup metrics and log files
+    var missing = tmpfile();
+    var different = tmpfile();
+    var extraneous = tmpfile();
+    var discrepancies = 0;
+
+    // Persist missing/extraneous records across scans
+    var lingeringMissing = {};
+    var lingeringExtraneous = {};
+
+    // async queue for performing repairs
+    var repairs = queue(config.parallel);
+
+    primaryDynamo.describeTable({ TableName: primaryTable }, function(err, data) {
+        var keyAttributes = _(data.Table.KeySchema).pluck('AttributeName');
+
+        // Construct pseudo-streams to consume data from DynamoDB
+        var primary = Scanner(primaryDynamo, primaryTable, keyAttributes);
+        var replica = Scanner(replicaDynamo, replicaTable, keyAttributes);
+
+        // Get moving
+        iterate();
+
+        function iterate() {
+            queue()
+                .defer(primary.read)
+                .defer(replica.read)
+                .await(compare);
+        }
+
+        function compare(err, primaryData, replicaData) {
+            if (err) return callback(err);
+
+            // Gather keys from the scan results
+            var primaryKeys = primaryData ? Object.keys(primaryData) : [];
+            var replicaKeys = replicaData ? Object.keys(replicaData) : [];
+
+            // Items missing from the replica scan
+            var missingInReplica = _(primaryKeys)
+                .difference(replicaKeys)
+                .map(function(key) {
+                    return primaryData[key];
+                });
+
+            // Extraneous items in the replica scan
+            var extraneousInReplica = _(replicaKeys)
+                .difference(primaryKeys)
+                .map(function(key) {
+                    return replicaData[key];
+                });
+
+            // Items that differ in the two scans
+            var differentInReplica = _(primaryKeys)
+                .intersection(replicaKeys)
+                .filter(function(key) {
+                    // Do I trust this equality check?? With buffers??
+                    return !_.isEqual(primaryData[key], replicaData[key]);
+                })
+                .map(function(key) {
+                    return primaryData[key];
+                });
+
+            // Aggregate comparison results
+            var result = {
+                different: differentInReplica,      // primary items different in replica
+                missing: missingInReplica,          // primary items missing from replica
+                extraneous: extraneousInReplica     // replica items missing from primary
+            };
+
+            // Missing/Extraneous items might exist because of mismatched scan
+            // lengths. These must be stashed across scan runs and checked on
+            // each iteration.
+            result.missing.forEach(function(missingItem) {
+                lingeringMissing[extractKey(missingItem, keyAttributes)] = missingItem;
+            });
+
+            result.extraneous.forEach(function(extraneousItem) {
+                lingeringExtraneous[extractKey(extraneousItem, keyAttributes)] = extraneousItem;
+            });
+
+            var missingKeys = Object.keys(lingeringMissing);
+            var extraneousKeys = Object.keys(lingeringExtraneous);
+
+            // Shared extraneous/missing keys are ones that showed up in
+            // separate scan iterations. These need to be compared.
+            _(missingKeys)
+                .intersection(extraneousKeys)
+                .forEach(function(key) {
+                    var primaryItem = lingeringMissing[key];
+                    var replicaItem = lingeringExtraneous[key];
+
+                    if (!_.isEqual(primaryItem, replicaItem))
+                        result.different.push(primaryItem);
+
+                    // Different or no, these items are no longer missing/extraneous
+                    delete lingeringMissing[key];
+                    delete lingeringExtraneous[key];
+                });
+
+            // Different items can be written to disk and repaired at this point
+            result.different.forEach(function(primaryItem) {
+                discrepancies++;
+                different.write(extractKey(primaryItem, keyAttributes) + '\n');
+
+                if (config.repair) {
+                    repairs.defer(replicaDynamo.putItem.bind(replicaDynamo), {
+                        Item: primaryItem,
+                        TableName: replicaTable
+                    });
+                }
+            });
+
+            // Ready for another iteration if there's anything left in either table
+            if (primaryKeys.length || replicaKeys.length) iterate();
+            else finish();
+        }
+
+        function finish() {
+            // Log and write [optionally] any missing items
+            _(lingeringMissing).each(function(primaryItem, key) {
+                discrepancies++;
+                missing.write(key + '\n');
+
+                if (config.repair) {
+                    repairs.defer(replicaDynamo.putItem.bind(replicaDynamo), {
+                        Item: primaryItem,
+                        TableName: replicaTable
+                    });
+                }
+            });
+
+            // Log and delete [optionally] any extraneous items
+            _(lingeringExtraneous).each(function(replicaItem, key) {
+                discrepancies++;
+                extraneous.write(key + '\n');
+
+                if (config.repair) {
+                    repairs.defer(replicaDynamo.deleteItem.bind(replicaDynamo), {
+                        Key: JSON.parse(key),
+                        TableName: replicaTable
+                    });
+                }
+            });
+
+            repairs.awaitAll(function(err) {
+                if (err) return callback(err);
+                callback(null, {
+                    missing: missing.filename,
+                    different: different.filename,
+                    extraneous: extraneous.filename,
+                    discrepancies: discrepancies
+                });
+            });
+        }
+    });
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test/index.js"
+    "test": "tap test/*.test.js"
   },
   "repository": {
     "type": "git",
@@ -17,10 +17,15 @@
   },
   "homepage": "https://github.com/mapbox/dynamodb-replicator",
   "dependencies": {
+    "aws-sdk": "^2.1.14",
+    "dyno": "^0.9.0",
+    "event-stream": "^3.2.2",
     "fastlog": "^1.0.0",
     "logger": "0.0.1",
+    "minimist": "^1.1.0",
     "queue-async": "^1.0.7",
-    "dyno": "^0.9.0"
+    "split": "^0.3.3",
+    "underscore": "^1.8.2"
   },
   "devDependencies": {
     "dynalite": "^0.5.2",

--- a/test/diff.test.js
+++ b/test/diff.test.js
@@ -1,0 +1,69 @@
+var test = require('tape');
+var setup = require('./setup')(process.env.LIVE_TEST);
+var diff = require('../diff');
+var _ = require('underscore');
+var config = _(setup.config).clone();
+var fs = require('fs');
+var exec = require('child_process').exec;
+
+var opts = { timeout: 600000 };
+
+test('setup', opts, setup.setup);
+
+test('diff: without repairs', opts, function(assert) {
+    diff(config, function(err, results) {
+        assert.ifError(err, 'diff tables');
+        if (err) return assert.end();
+
+        assert.equal(results.discrepancies, 3, 'three discrepacies');
+
+        var extraneous = fs.readFileSync(results.extraneous, 'utf8');
+        var missing = fs.readFileSync(results.missing, 'utf8');
+        var different = fs.readFileSync(results.different, 'utf8');
+
+        assert.equal(extraneous, '{"hash":{"S":"hash1"},"range":{"S":"range3"}}\n', 'expected extraneous record');
+        assert.equal(missing, '{"hash":{"S":"hash1"},"range":{"S":"range1"}}\n', 'expected missing record');
+        assert.equal(different, '{"hash":{"S":"hash1"},"range":{"S":"range2"}}\n', 'expected different record');
+
+        assert.end();
+    });
+});
+
+test('diff: with repairs', opts, function(assert) {
+    config.repair = true;
+
+    diff(config, function(err, results) {
+        assert.ifError(err, 'diff tables');
+        if (err) return assert.end();
+
+        assert.equal(results.discrepancies, 3, 'three discrepacies');
+
+        var extraneous = fs.readFileSync(results.extraneous, 'utf8');
+        var missing = fs.readFileSync(results.missing, 'utf8');
+        var different = fs.readFileSync(results.different, 'utf8');
+
+        assert.equal(extraneous, '{"hash":{"S":"hash1"},"range":{"S":"range3"}}\n', 'expected extraneous record');
+        assert.equal(missing, '{"hash":{"S":"hash1"},"range":{"S":"range1"}}\n', 'expected missing record');
+        assert.equal(different, '{"hash":{"S":"hash1"},"range":{"S":"range2"}}\n', 'expected different record');
+
+        config.repair = false;
+        diff(config, function(err, results) {
+            assert.ifError(err, 'diff tables');
+            if (err) return assert.end();
+
+            assert.equal(results.discrepancies, 0, 'no discrepacies');
+
+            var extraneous = fs.readFileSync(results.extraneous, 'utf8');
+            var missing = fs.readFileSync(results.missing, 'utf8');
+            var different = fs.readFileSync(results.different, 'utf8');
+
+            assert.notOk(extraneous, 'no extraneous logged');
+            assert.notOk(missing, 'no missing logged');
+            assert.notOk(different, 'no different logged');
+
+            assert.end();
+        });
+    });
+});
+
+test('teardown', opts, setup.teardown);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,7 @@
 var test = require('tap').test,
     fs = require('fs'),
     queue = require('queue-async');
-var s = require('./setup');
+var s = require('./setup')();
 var config = s.config;
 var dynos = s.dynos;
 


### PR DESCRIPTION
Compare to #1 

The idea is, scan for one page of data from both tables. Compare the results of the two scans. If the tables are the same, then the results of each scan will be ordered in the same way, and the results of each page will be the same. At this point we can detect differences: missing from replica, extra in replica, or different in replica.

### Advantages
- Finds and deletes extra records in the replica table
- Performs scans on both tables instead of a scan on the primary + getItem requests on the secondary

### Disadvantages
- Convoluted. Maybe my logic is a mess and it just needs another set of eyes. If the replica is missing a primary item, suddenly *the results of all successive scans will never be identical ever again*. You have to keep a running index of extraneous and missing records and see if you've resolved any each time you scan another page.

cc @freenerd @mick @willwhite 