### PR TITLE
Backup standalone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,7 @@ language: node_js
 node_js:
   - "0.10"
 sudo: false
-script: './node_modules/.bin/tap test/index.js'
+env:
+  global:
+  - secure: "m9pXrJEeitDYKxDQWLYW5hBRZrG3zxr2g9L8zs5CRL6D7h6xxd7qqxJW3odAOIWmlO48z0aDL7/iJLVo0fpk0KnnQrRir+D0BVftP44g7nyYQiusxxcCcrnX8mTRtMeNsFL9HuAr50/zcU9zl13zV3utt//F6JmPmxPKaImjQO4="
+  - secure: "fe9nSC6XAAdlaGUzufarmWq9UGqaFs712TFLxQ4Cwx4EW+rKNJ4+vwHTKsGm32lpxreDKxEdKm3zb7pMBLqFHCb+VIMDxDnTobMv7MIFQ8GK2irCQ+KDX15gA5322Zs5PImgI74a8zng2+7GAMjxrtsxkwETA0x37UoVMs0bzPg="

--- a/README.md
+++ b/README.md
@@ -1,24 +1,18 @@
 # dynamodb-replicator
 
-[dynamodb-replicator](https://github.com/mapbox/dynamodb-replicator) consumes a Kinesis stream of DynamoDB changes (keys-only) and writes them to a replica DynamoDB table. dynamodb-replicator is compatible with the upcoming DynamoDB streams ([in preview](http://dynamodb-preview.s3-website-us-west-2.amazonaws.com/docs/streams-dg/About.html)) as well as [dyno](https://github.com/mapbox/dyno) with Kinesis ([available already](https://github.com/mapbox/dyno#multi--kinesisconfig)).
+[dynamodb-replicator](https://github.com/mapbox/dynamodb-replicator) offers three different mechanisms to provide redundancy and recoverability on DynamoDB tables using a primary-replica model:
 
-[dynamodb-replicator](https://github.com/mapbox/dynamodb-replicator) also provides a `diff-tables` script to compare two tables and bring them in sync with one another.
-
-### Features
-
-- Primary-Replica replication between DynamoDB tables in different regions
-- Replication streaming based on Kinesis
-- Stream consists of object ids only (_KEYS_ONLY_), no changes or full items
-- Compatible with [upcoming DynamoDB Streams](http://dynamodb-preview.s3-website-us-west-2.amazonaws.com/docs/streams-dg/About.html) and current [dyno with Kinesis](https://github.com/mapbox/dyno#multi--kinesisconfig)
-- Ability to replay old stream events for bootstrapping a new replica, disaster recovery and ensuring consistency
+- A **replicator** function that processes records from a Kinesis stream of DynamoDB changes made to the primary table and writes them to a replica DynamoDB table. dynamodb-replicator is compatible with the upcoming DynamoDB streams ([in preview](http://dynamodb-preview.s3-website-us-west-2.amazonaws.com/docs/streams-dg/About.html)) as well as [dyno](https://github.com/mapbox/dyno) with Kinesis ([available already](https://github.com/mapbox/dyno#multi--kinesisconfig)). The function is designed to be used along with the [Node Kinesis Client Library](https://github.com/evansolomon/nodejs-kinesis-client-library) in your own project.
+- A **diff-tables** script to that scans the primary table, and checks that each individual record in the replica table is up-to-date
+- A **backup-table** script that scans a single table, and writes the data to files on S3
 
 ### Design
 
 Replication involves many moving parts, of which dynamodb-replicator is only one. Please read [DESIGN.md](https://github.com/mapbox/dynamodb-replicator/blob/master/DESIGN.md) for an in-depth explaination.
 
-### Replicator usage
+### replicator usage
 
-dynamodb-replicator is designed to be used along with the [Node Kinesis Client Library](https://github.com/evansolomon/nodejs-kinesis-client-library) in your own project:
+The replicator function is designed to be used along with the [Node Kinesis Client Library](https://github.com/evansolomon/nodejs-kinesis-client-library) in your own project:
 
 With a `consumer.js`:
 
@@ -74,4 +68,29 @@ $ diff-tables us-east-1/primary eu-west-2/new-replica --backfill --repair
 
 # Perform one segment of a parallel scan
 $ diff-tables us-east-1/primar eu-west-2/replica --repair --segment 0 --segments 10
+```
+
+### backup-table usage
+
+```
+$ npm install -g dynamodb-replicator
+$ backup-table --help
+
+Usage: backup-table region/table s3url
+
+Options:
+  --jobid      assign a jobid to this backup
+  --segment    segment identifier (0-based)
+  --segments   total number of segments
+
+# Writes a backup file to s3://my-bucket/some-prefix/<random string>/0
+$ backup-table us-east-1/primary s3://my-bucket/some-prefix
+
+# Specifying a jobid guarantees the S3 location
+# Writes a backup file to s3://my-bucket/some-prefix/my-job-id/0
+$ backup-table us-east-1/primary s3://my-bucket/some-prefix --jobid my-job-id
+
+# Perform one segment of a parallel backup
+# Writes a backup file to s3://my-bucket/some-prefix/my-job-id/4
+$ backup-table us-east-1/primary s3://my-bucket/some-prefix --jobid my-job-id --segment 4 --segments 10
 ```

--- a/backup.js
+++ b/backup.js
@@ -40,11 +40,10 @@ module.exports = function(config, done) {
         });
 
         var ready = writeBackup.upload.write(line + '\n');
-        this.push(record);
         writeBackup.count++;
 
         if (ready) return callback();
-        writeBackup.upload.on('drain', callback);
+        writeBackup.upload.once('drain', callback);
     };
 
     writeBackup._flush = function(callback) {
@@ -65,7 +64,8 @@ module.exports = function(config, done) {
                 .on('error', next)
                 .pipe(writeBackup)
                 .on('error', next)
-                .on('finish', next);
+                .on('end', next)
+                .resume();
         })
         .awaitAll(function(backupErr) {
             throughput.resetCapacity(function(resetErr) {

--- a/backup.js
+++ b/backup.js
@@ -55,7 +55,7 @@ module.exports = function(config, done) {
         writeBackup.upload.end();
     };
 
-    var report;
+    log('[segment %s] Starting backup job %s of %s', index, config.jobid, config.region + '/' + config.table);
 
     queue(1)
         .defer(throughput.setCapacity, { read: 1000 })

--- a/backup.js
+++ b/backup.js
@@ -27,7 +27,7 @@ module.exports = function(config, done) {
     }).on('error', function(err) {
         writeBackup.emit('error', err);
     }).on('part', function(details) {
-        log('[segment %s] Uploaded part #%s for total %s bytes uploaded', details.PartNumber, details.uploadedSize);
+        log('[segment %s] Uploaded part #%s for total %s bytes uploaded', index, details.PartNumber, details.uploadedSize);
     });
 
     writeBackup.count = 0;
@@ -61,10 +61,6 @@ module.exports = function(config, done) {
     queue(1)
         .defer(throughput.setCapacity, { read: 1000 })
         .defer(function(next) {
-            report = setInterval(function() {
-                log('[segment %s] Wrote %s items to backup', index, writeBackup.count);
-            }, 1 * 1000);
-
             primary.scan(scanOpts)
                 .on('error', next)
                 .pipe(writeBackup)
@@ -72,8 +68,6 @@ module.exports = function(config, done) {
                 .on('finish', next);
         })
         .awaitAll(function(backupErr) {
-            clearInterval(report);
-
             throughput.resetCapacity(function(resetErr) {
                 if (backupErr) return done(backupErr);
                 if (resetErr) return done(resetErr);

--- a/backup.js
+++ b/backup.js
@@ -55,7 +55,7 @@ module.exports = function(config, done) {
         writeBackup.upload.end();
     };
 
-    log('[segment %s] Starting backup job %s of %s', index, config.jobid, config.region + '/' + config.table);
+    log('[segment %s] Starting backup job %s of %s', index, config.backup.jobid, config.region + '/' + config.table);
 
     queue(1)
         .defer(throughput.setCapacity, { read: 1000 })

--- a/backup.js
+++ b/backup.js
@@ -1,0 +1,79 @@
+var AWS = require('aws-sdk');
+var s3Stream = require('s3-upload-stream')(new AWS.S3());
+var queue = require('queue-async');
+var Dyno = require('dyno');
+var stream = require('stream');
+
+module.exports = function(config, done) {
+    var primary = Dyno(config);
+    var throughput = require('dynamodb-throughput')(config.table, { region: config.region });
+
+    var log = config.log || console.log;
+    var scanOpts = config.hasOwnProperty('segment') && config.segments ?
+        { segment: config.segment, segments: config.segments } : undefined;
+
+    if (config.backup)
+        if (!config.backup.bucket || !config.backup.prefix || !config.backup.jobid)
+            return done(new Error('Must provide a bucket, prefix and jobid for backups'));
+
+    var index = !isNaN(parseInt(config.segment)) ? config.segment.toString() : 0;
+    var key = [config.backup.prefix, config.backup.jobid, index].join('/');
+
+    var writeBackup = new stream.Transform({ objectMode: true });
+
+    writeBackup.upload = s3Stream.upload({
+        Bucket: config.backup.bucket,
+        Key: key
+    }).on('error', function(err) {
+        writeBackup.emit('error', err);
+    });
+
+    writeBackup.count = 0;
+
+    writeBackup._transform = function(record, enc, callback) {
+        var line = JSON.stringify(record, function(key) {
+            var value = this[key];
+            if (Buffer.isBuffer(value)) return 'base64:' + value.toString('base64');
+            return value;
+        });
+
+        writeBackup.upload.write(line + '\n');
+        this.push(record);
+        writeBackup.count++;
+        callback();
+    };
+
+    writeBackup._flush = function(callback) {
+        writeBackup.upload.on('uploaded', function(uploadInfo) {
+            log('[segment %s] Uploaded dynamo backup to s3://%s/%s', index, config.backup.bucket, key);
+            log('[segment %s] Wrote %s items to backup', index, writeBackup.count);
+            callback();
+        });
+        writeBackup.upload.end();
+    };
+
+    var report;
+
+    queue(1)
+        .defer(throughput.setCapacity, { read: 1000 })
+        .defer(function(next) {
+            report = setInterval(function() {
+                log('[segment %s] Wrote %s items to backup', index, writeBackup.count);
+            }, 1 * 1000);
+
+            primary.scan(scanOpts)
+                .on('error', next)
+                .pipe(writeBackup)
+                .on('error', next)
+                .on('finish', next);
+        })
+        .awaitAll(function(backupErr) {
+            clearInterval(report);
+
+            throughput.resetCapacity(function(resetErr) {
+                if (backupErr) return done(backupErr);
+                if (resetErr) return done(resetErr);
+                done();
+            });
+        });
+};

--- a/backup.js
+++ b/backup.js
@@ -6,7 +6,7 @@ var stream = require('stream');
 
 module.exports = function(config, done) {
     var primary = Dyno(config);
-    var throughput = require('dynamodb-throughput')(config.table, { region: config.region });
+    var throughput = require('dynamodb-throughput')(config.table, config);
 
     var log = config.log || console.log;
     var scanOpts = config.hasOwnProperty('segment') && config.segments ?

--- a/bin/backup-table.js
+++ b/bin/backup-table.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+var fs = require('fs');
+var backup = require('../backup');
+var fastlog = require('fastlog');
+var args = require('minimist')(process.argv.slice(2));
+var crypto = require('crypto');
+var s3urls = require('s3urls');
+
+function usage() {
+    console.error('');
+    console.error('Usage: backup-table region/table s3url');
+    console.error('');
+    console.error('Options:');
+    console.error('  --jobid      assign a jobid to this backup');
+    console.error('  --segment    segment identifier (0-based)');
+    console.error('  --segments   total number of segments');
+}
+
+if (args.help) {
+    usage();
+    process.exit(0);
+}
+
+var table = args._[0];
+
+if (!table) {
+    console.error('Must provide table information');
+    usage();
+    process.exit(1);
+}
+
+table = table.split('/');
+
+var s3url = args._[1];
+
+if (!s3url) {
+    console.error('Must provide an s3url');
+    usage();
+    process.exit(1);
+}
+
+s3url = s3urls.fromUrl(s3url);
+
+var jobid = args.jobid || crypto.randomBytes(8).toString('hex');
+var format = '[${timestamp}] [${level}] [${category}] [' + jobid + ']';
+var log = fastlog('backup-table', 'info', format);
+var index = !isNaN(parseInt(args.segment)) ? args.segment.toString() : 0;
+
+var config = {
+    region: table[0],
+    table: table[1],
+    segment: args.segment,
+    segments: args.segments,
+    log: log.info,
+    backup: {
+        bucket: s3url.Bucket,
+        prefix: s3url.Key,
+        jobid: jobid
+    }
+};
+
+log.info('[segment %s] Starting backup of %s', index, jobid, args._[0]);
+backup(config, function(err) {
+    if (err) {
+        log.error(err);
+        process.exit(1);
+    }
+});

--- a/bin/backup-table.js
+++ b/bin/backup-table.js
@@ -60,7 +60,7 @@ var config = {
     }
 };
 
-log.info('[segment %s] Starting backup of %s', index, jobid, args._[0]);
+log.info('[segment %s] Starting backup job %s of %s', index, jobid, args._[0]);
 backup(config, function(err) {
     if (err) {
         log.error(err);

--- a/bin/backup-table.js
+++ b/bin/backup-table.js
@@ -60,7 +60,6 @@ var config = {
     }
 };
 
-log.info('[segment %s] Starting backup job %s of %s', index, jobid, args._[0]);
 backup(config, function(err) {
     if (err) {
         log.error(err);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "tap test/*.test.js"
+    "test": "tape test/*.test.js"
   },
   "bin": {
     "diff-tables": "bin/diff-tables.js",
@@ -36,6 +36,6 @@
   },
   "devDependencies": {
     "dynalite": "^0.5.2",
-    "tap": "^0.6.0"
+    "tape": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "tap test/*.test.js"
   },
   "bin": {
-    "diff-tables": "bin/diff-tables.js"
+    "diff-tables": "bin/diff-tables.js",
+    "backup-table": "bin/backup-table.js"
   },
   "repository": {
     "type": "git",
@@ -20,12 +21,16 @@
   },
   "homepage": "https://github.com/mapbox/dynamodb-replicator",
   "dependencies": {
+    "aws-sdk": "^2.1.24",
+    "dynamodb-throughput": "0.0.5",
     "dyno": "^0.11.0",
     "event-stream": "^3.2.2",
     "fastlog": "^1.0.0",
     "logger": "0.0.1",
     "minimist": "^1.1.0",
     "queue-async": "^1.0.7",
+    "s3-upload-stream": "^1.0.7",
+    "s3urls": "^1.3.0",
     "split": "^0.3.3",
     "underscore": "^1.8.2"
   },

--- a/test/backup.test.js
+++ b/test/backup.test.js
@@ -1,0 +1,103 @@
+var test = require('tape');
+var setup = require('./setup')(process.env.LIVE_TEST);
+var backup = require('../backup');
+var _ = require('underscore');
+var crypto = require('crypto');
+var AWS = require('aws-sdk');
+var s3 = new AWS.S3();
+var queue = require('queue-async');
+
+test('setup', setup.setup);
+test('backup: one segment', function(assert) {
+    var config = {
+        backup: {
+            bucket: 'mapbox',
+            prefix: 'dynamodb-replicator/test',
+            jobid: crypto.randomBytes(4).toString('hex')
+        },
+        table: setup.config.primary.table,
+        region: setup.config.primary.region,
+        accessKeyId: setup.config.primary.accessKeyId,
+        secretAccessKey: setup.config.primary.secretAccessKey,
+        endpoint: setup.config.primary.endpoint
+    };
+
+    backup(config, function(err) {
+        assert.ifError(err, 'backup completed');
+        if (err) return assert.end();
+
+        s3.getObject({
+            Bucket: 'mapbox',
+            Key: [config.backup.prefix, config.backup.jobid, '0'].join('/')
+        }, function(err, data) {
+            assert.ifError(err, 'retrieved backup from S3');
+            if (err) return assert.end();
+
+            assert.ok(data.Body, 'file has content');
+
+            data = data.Body.toString().trim().split('\n');
+            assert.deepEqual(data, [
+                '{"hash":"hash1","range":"range1","other":1}',
+                '{"hash":"hash1","range":"range2","other":2}',
+                '{"hash":"hash1","range":"range4","other":"base64:aGVsbG8gd29ybGQ="}'
+            ], 'expected data backed up to S3');
+
+            assert.end();
+        });
+    });
+});
+test('teardown', setup.teardown);
+
+test('setup', setup.setup);
+test('load many', function(assert) {
+    var records = _.range(1000).map(function() {
+        return {
+            hash: crypto.randomBytes(8).toString('hex'),
+            range: crypto.randomBytes(8).toString('hex'),
+            other: crypto.randomBytes(8)
+        };
+    });
+
+    setup.dynos.primary.putItems(records, function(err) {
+        if (err) throw err;
+        assert.end();
+    });
+});
+test('backup: parallel', function(assert) {
+    var config = {
+        backup: {
+            bucket: 'mapbox',
+            prefix: 'dynamodb-replicator/test',
+            jobid: crypto.randomBytes(4).toString('hex')
+        },
+        table: setup.config.primary.table,
+        region: setup.config.primary.region,
+        accessKeyId: setup.config.primary.accessKeyId,
+        secretAccessKey: setup.config.primary.secretAccessKey,
+        endpoint: setup.config.primary.endpoint,
+        segments: 2
+    };
+
+    var firstConfig = _({ segment: 0 }).extend(config);
+    var secondConfig = _({ segment: 1 }).extend(config);
+    var firstKey = [config.backup.prefix, config.backup.jobid, firstConfig.segment].join('/');
+    var secondKey = [config.backup.prefix, config.backup.jobid, secondConfig.segment].join('/');
+
+    queue(1)
+        .defer(backup, firstConfig)
+        .defer(backup, secondConfig)
+        .defer(s3.getObject.bind(s3), { Bucket: 'mapbox', Key: firstKey })
+        .defer(s3.getObject.bind(s3), { Bucket: 'mapbox', Key: secondKey })
+        .awaitAll(function(err, results) {
+            assert.ifError(err, 'all requests completed');
+            if (err) return assert.end();
+
+            var data = results.slice(2).map(function(s3result) {
+                return s3result.Body.toString().trim().split('\n');
+            });
+
+            assert.equal(data[0].length + data[1].length, 1003, 'backed up all records');
+            assert.end();
+        });
+});
+test('teardown', setup.teardown);

--- a/test/diff.test.js
+++ b/test/diff.test.js
@@ -5,17 +5,15 @@ var _ = require('underscore');
 var fs = require('fs');
 var util = require('util');
 
-var opts = { timeout: 600000 };
-
 var config = _(setup.config).clone();
 config.log = function() {
     config.log.messages.push(util.format.apply(this, arguments));
 };
 config.log.messages = [];
 
-test('setup', opts, setup.setup);
+test('setup', setup.setup);
 
-test('diff: without repairs', opts, function(assert) {
+test('diff: without repairs', function(assert) {
     config.repair = false;
     config.log.messages = [];
 
@@ -60,7 +58,7 @@ test('diff: without repairs', opts, function(assert) {
 
 });
 
-test('diff: with repairs', opts, function(assert) {
+test('diff: with repairs', function(assert) {
     config.repair = true;
     config.log.messages = [];
 
@@ -101,8 +99,8 @@ test('diff: with repairs', opts, function(assert) {
 });
 test('teardown', setup.teardown);
 
-test('setup', opts, setup.setup);
-test('diff: backfill', opts, function(assert) {
+test('setup', setup.setup);
+test('diff: backfill', function(assert) {
     config.repair = true;
     config.backfill = true;
     config.log.messages = [];
@@ -137,8 +135,8 @@ test('diff: backfill', opts, function(assert) {
 });
 test('teardown', setup.teardown);
 
-test('setup', opts, setup.setup);
-test('diff: parallel', opts, function(assert) {
+test('setup', setup.setup);
+test('diff: parallel', function(assert) {
     config.repair = false;
     config.backfill = false;
     config.segment = 0;
@@ -158,4 +156,4 @@ test('diff: parallel', opts, function(assert) {
     });
 });
 
-test('teardown', opts, setup.teardown);
+test('teardown', setup.teardown);

--- a/test/diff.test.js
+++ b/test/diff.test.js
@@ -1,4 +1,4 @@
-var test = require('tap').test;
+var test = require('tape');
 var setup = require('./setup')(process.env.LIVE_TEST);
 var diff = require('../diff');
 var _ = require('underscore');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,4 @@
-var test = require('tap').test,
+var test = require('tape'),
     fs = require('fs'),
     queue = require('queue-async');
 var s = require('./setup')();

--- a/test/setup.js
+++ b/test/setup.js
@@ -43,7 +43,9 @@ module.exports = function(live) {
     dynos.primary = require('dyno')(config.primary);
     dynos.replica = require('dyno')(config.replica);
 
-    setup.setup = function(t) {
+    setup.setup = function(assert) {
+        assert.timeoutAfter(600000);
+
         if (live) return setupTables();
 
         dynalite = Dynalite({
@@ -53,7 +55,7 @@ module.exports = function(live) {
         });
 
         dynalite.listen(4567, function() {
-            t.pass('dynalite listening');
+            assert.pass('dynalite listening');
             setupTables();
         });
 
@@ -69,8 +71,8 @@ module.exports = function(live) {
             });
 
             q.awaitAll(function(err, resp) {
-                t.notOk(err, 'no error creating tables');
-                t.end();
+                assert.notOk(err, 'no error creating tables');
+                assert.end();
             });
         }
     };
@@ -108,17 +110,19 @@ module.exports = function(live) {
         q.awaitAll(callback);
     };
 
-    setup.teardown = function(t) {
+    setup.teardown = function(assert) {
+        assert.timeoutAfter(600000);
+
         if (!live) {
             dynalite.close();
-            return t.end();
+            return assert.end();
         }
 
         queue(1)
             .defer(dynos.primary.deleteTable, config.primary.table)
             .defer(dynos.replica.deleteTable, config.replica.table)
             .awaitAll(function(err) {
-                t.end(err);
+                assert.end(err);
             });
     };
 

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,4 +1,4 @@
-var test = require('tap').test;
+var test = require('tape');
 var queue = require('queue-async');
 var crypto = require('crypto');
 var Dynalite = require('dynalite');


### PR DESCRIPTION
Borrowing heavily from @bsudekum's work in #3, this sketches splitting out the backup routine into a standalone executable, which could feasibly support parallel scans. 

The idea for parallel-scan support is that you could specify a `jobid`, and this would become part of the S3 location where your backup files are written. Some kind of master process could assign a `jobid` and then spawn a set of processes or EC2s to run out the backup in parallel. A restore routine would read from all the files written to the S3 location.

### Questions and next steps
- I think we should provide both this standalone script AND the backup-while-you-diff approach from #3. We should figure out how to share redundant code effectively.
- write tests
- readme needs work