### PR TITLE
Metrics, back to setCapacity

### DIFF
--- a/test/backup.test.js
+++ b/test/backup.test.js
@@ -22,9 +22,12 @@ test('backup: one segment', function(assert) {
         endpoint: setup.config.primary.endpoint
     };
 
-    backup(config, function(err) {
+    backup(config, function(err, details) {
         assert.ifError(err, 'backup completed');
         if (err) return assert.end();
+
+        assert.equal(details.count, 3, 'reported 3 records');
+        assert.equal(details.size, 156, 'reported 156 bytes');
 
         s3.getObject({
             Bucket: 'mapbox',
@@ -91,6 +94,9 @@ test('backup: parallel', function(assert) {
         .awaitAll(function(err, results) {
             assert.ifError(err, 'all requests completed');
             if (err) return assert.end();
+
+            assert.equal(results[0].count + results[1].count, 1003, 'reported 1003 records');
+            assert.equal(results[0].size + results[1].size, 85156, 'reported 85156 bytes');
 
             var data = results.slice(2).map(function(s3result) {
                 return s3result.Body.toString().trim().split('\n');


### PR DESCRIPTION
Allows `backup-table.js` script to accept a `--metric` flag. If specified, data will be written to the given namespace/metric-name indicating:
- `Type: Size`: backup size in bytes
- `Type: RecordCount`: number of records written to the backup file
- `Type: Error`: `1` if an error is encountered.

The script no longer `exit 1` in the event that backing up encountered an error.

Switches back to setting capacity to a specific value rather than adding to whatever exists, preventing run-away capacity scenarios.