### PR TITLE
Do not adjust throughput during backups

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "homepage": "https://github.com/mapbox/dynamodb-replicator",
   "dependencies": {
     "aws-sdk": "^2.1.24",
-    "dynamodb-throughput": "^0.1.0",
     "dyno": "^0.13.1",
     "event-stream": "^3.2.2",
     "fastlog": "^1.0.0",


### PR DESCRIPTION
Automated throughput adjustment is a trap, because scaling up can increase the number of partitions in your table, and then scaling down leaves that number of partitions with lower throughput per partition. 