### PR TITLE
Backfill shouldn't do any comparison

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -49,6 +49,13 @@ module.exports = function(config, done) {
                 return key;
             }, {});
 
+            if (config.backfill) {
+                log('[backfill] %j', key);
+                writable.discrepancies++;
+                itemsCompared++;
+                return replica.putItem(record, callback);
+            }
+
             read.getItem(key, function(err, item) {
                 itemsCompared++;
                 if (err) return writable.emit('error', err);

--- a/test/diff.test.js
+++ b/test/diff.test.js
@@ -113,26 +113,31 @@ test('diff: backfill', function(assert) {
         assert.ifError(err, 'diff tables');
         if (err) return assert.end();
 
-        assert.equal(discrepancies, 2, 'two discrepacies');
+        assert.equal(discrepancies, 3, 'three records backfilled');
         assert.deepEqual(config.log.messages, [
             'Scanning primary table and comparing to replica',
-            '[missing] {"hash":"hash1","range":"range1"}',
-            '[different] {"hash":"hash1","range":"range2"}',
-            '[discrepancies] 2',
+            '[backfill] {"hash":"hash1","range":"range1"}',
+            '[backfill] {"hash":"hash1","range":"range2"}',
+            '[backfill] {"hash":"hash1","range":"range4"}',
+            '[discrepancies] 3',
             '[progress] Scan rate: 3 items @ 3 items/s, 1 scans/s | Compare rate: 3 items/s'
         ]);
 
         config.repair = false;
+        config.backfill = false;
         config.log.messages = [];
         diff(config, function(err, discrepancies) {
             assert.ifError(err, 'diff tables');
             if (err) return assert.end();
 
-            assert.equal(discrepancies, 0, 'no discrepacies on second comparison');
+            assert.equal(discrepancies, 1, 'only an extraneous discrepacy on second comparison');
             assert.deepEqual(config.log.messages, [
                 'Scanning primary table and comparing to replica',
                 '[discrepancies] 0',
-                '[progress] Scan rate: 3 items @ 3 items/s, 1 scans/s | Compare rate: 3 items/s'
+                'Scanning replica table and comparing to primary',
+                '[extraneous] {"hash":"hash1","range":"range3"}',
+                '[discrepancies] 1',
+                '[progress] Scan rate: 7 items @ 7 items/s, 2 scans/s | Compare rate: 7 items/s'
             ]);
 
             assert.end();


### PR DESCRIPTION
When backfilling, just copy every record into the replica, no need to check for it being there first.