### PR TITLE
Use a lambda function instead of node-kcl

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,65 +1,76 @@
 # Design
 
-### Flow of events and data
+## Replication
 
-- All writes (_put_, _update_, _delete_) from all regions go to the DynamoDB primary table
-- When an item's write to the DynamoDB primary table is confirmed, the item key is written to the Kinesis stream in the primary region
-- An instance of [dynamodb-replicator](https://github.com/mapbox/dynamodb-replicator) consumes the Kinesis stream in the primary region
-    - For each item key on the Kinesis stream, [dynamodb-replicator](https://github.com/mapbox/dynamodb-replicator) reads the item as DynamoDB consistent read from the Primary table and writes the item to the Replica table
+This replication system is built such that there is a **primary** table and a **replica** table. All writes are performed against the primary table, and changes made to the primary table are pushed to the replica table. Reads can be performed against either the primary or replica table.
 
-```
-primary region
+[Dyno](https://github.com/mapbox/dyno), the client that we use for interactions with DynamoDB can be [configured to read from one table and write to another](https://github.com/mapbox/dyno#multi--kinesisconfig). Also, by providing dyno with information about an existing Kinesis stream, it can write a record to that stream each time it makes a write to the primary DynamoDB table. This Kinesis stream plays the role of a surrogate DynamoDB stream. The primary table has a Kinesis stream associated with it, while the replica table does not.
 
-+----------------+ +----------+
-|DynamoDB Primary| |Kinesis   |
-+-^--------------+ ++---------+
-  |                 |
-  |read             |put
-  |write            |
-  |                 |
-  |                 |
-+-+-------------+   |
-|dyno           +---^
-+---------------+
-```
+The actual replication is performed via an [AWS Lambda function](https://github.com/mapbox/dynamodb-replicator/blob/master/index.js) which reads from the primary table's Kinesis stream, and duplicates those changes in the replica table.
 
 ```
-primary region                       replica region     
-                                                        
-+----------------+ +----------+      +----------------+ 
-|DynamoDB Primary| |Kinesis   |      |DynamoDB Replica| 
-+-^------^-------+ +^-----^---+      +^-----------^---+ 
-  |      |          |     |           |           |     
-  |read  |write     |put  |consume    |read       |write
-  |      |          |     |           |           |     
-  |      |          |     |          ++-----+     |     
-  |      ^----------+----------------+dyno  |     |     
-  |                       |          +------+     |     
-  |                       |                       |     
-  |       +---------------+---+                   |     
-  ^-------+dynamodb replicator+-------------------+     
-          +-------------------+                         
+ us-east-1                         eu-west-1
+-----------                       -----------
+|   api   |                       |   api   |
+-----------                       -----------
+  ↑     |                           |     ↑
+  |     |                           |     |
+  |     ↓                           |     |
+  |   writes ←----------------------+     |
+  |   |    |                              |
+reads |    |                            reads
+  |   |    +~~~~ kinesis stream ~~~~+     |
+  |   |                             |     |
+  |   |                           writes  |
+  |   |                             |     |
+  |   ↓                             ↓     |
+-----------                       -----------
+|         |                       |         |
+| primary |                       | replica |
+|  table  |                       |  table  |
+|         |                       |         |
+-----------                       -----------
 ```
 
-### Expected Kinesis record format
+## Repair
+
+The [diff-tables script provided by dynamodb-replicator](https://github.com/mapbox/dynamodb-replicator/blob/master/bin/diff-tables.js) slowly scans the primary table, and record-by-record checks that the replica table's data is up-to-date. If it encounters any discrepancies, the data in the replica table is updated to match the primary table. This script can also be used to backfill a brand new replica table.
 
 ```
-{
-    "awsRegion": "us-east-1",
-    "dynamodb": {
-        "Keys": {
-            "ForumName": {"S": "DynamoDB"},
-            "Subject": {"S": "DynamoDB Thread 3"}
-        },
-        "SequenceNumber": "300000000000000499659",
-        "SizeBytes": 41,
-        "StreamViewType": "KEYS_ONLY"
-    },
-    "eventID": "e2fd9c34eff2d779b297b26f5fef4206",
-    "eventName": "INSERT",
-    "eventSource": "aws:dynamodb",
-    "eventVersion": "1.0"
-},
+        primary                                     replica
+------------------------                    ------------------------
+| hash | range | value |                    | hash | range | value |
+------------------------ --+                ------------------------
+|  10  |   1   |   1   |   |  get set   --→ |  10  |   1   |   1   | ✔
+------------------------   | of primary     ------------------------
+|  10  |   2   |   7   |   |  records   --→ |  10  |   2   |   7   | ✔
+------------------------   |                ------------------------
+|  11  |   1   |   3   |   | check each --→ |  11  |   1   |   3   | ✔
+------------------------   | individual     ------------------------
+|  12  |   1   |   4   |   | in replica --→ |  12  |   1   |   8   | ✘ Repair this!
+------------------------ --+                ------------------------
+
+                            ...repeat...
+
+------------------------ --+                ------------------------
+|  13  |   1   |   3   |   |  get set   --→ |  13  |   1   |   3   | ✔
+------------------------   | of primary     ------------------------
+|  13  |   2   |   5   |   |  records   --→ |  13  |   2   |   7   | ✘ Repair this!
+------------------------   |                ------------------------
+|  14  |   1   |   4   |   | check each --→ |  14  |   1   |   4   | ✔
+------------------------   | individual     ------------------------
+|  15  |   1   |   6   |   | in replica --→ |  15  |   1   |   6   | ✔
+------------------------ --+                ------------------------
 ```
 
-The record format is compatible with the format of the [DynamoDB Streams Preview](http://dynamodb-preview.s3-website-us-west-2.amazonaws.com/docs/streams-dg/About.html).
+This gives us a system where changes to the primary table are rapidly implemented in the replica tables via Kinesis + Lambda **replication**. The **replica repair** system gives us additional certainty that replication is doing its job, and provides a system by which we can recover a database in one region by reading the data out of a table in another region.
+
+## Backup and Restore
+
+The backup-table script [reads each record from a table and writes it to a file on S3](https://github.com/mapbox/dynamodb-replicator/blob/master/bin/backup-table.js). Running this script on a regular basis helps build resiliency against data corruption: if corrupt data were located, a trail of past states exists on S3 that can be recovered from. 
+
+[Dyno has a CLI](https://github.com/mapbox/dyno#usage) that includes an `import` command that can be used to read the backup data back into a table. This can be used to recover an entire database from an S3 backups. Running a restore looks something like:
+
+```sh
+$ npm install -g s3print dyno
+$ s3print s3://my-bucket/my-database-backup | dyno put us-east-1/my-new-database

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "bin": {
     "diff-tables": "bin/diff-tables.js",
+    "diff-record": "bin/diff-record.js",
     "backup-table": "bin/backup-table.js"
   },
   "repository": {
@@ -31,10 +32,13 @@
     "s3-upload-stream": "^1.0.7",
     "s3urls": "^1.3.0",
     "split": "^0.3.3",
+    "streambot": "^2.0.6",
     "underscore": "^1.8.2"
   },
   "devDependencies": {
     "dynalite": "^0.5.2",
+    "dynamodb-test": "^0.1.0",
+    "kinesis-test": "^0.1.1",
     "tape": "^4.0.0"
   }
 }

--- a/test/fixtures/records.js
+++ b/test/fixtures/records.js
@@ -1,0 +1,11 @@
+var crypto = require('crypto');
+var _ = require('underscore');
+
+module.exports = function(num) {
+    return _.range(0, num).map(function() {
+        return {
+            id: crypto.randomBytes(16).toString('hex'),
+            data: crypto.randomBytes(256).toString('base64')
+        };
+    });
+};

--- a/test/fixtures/table.js
+++ b/test/fixtures/table.js
@@ -1,0 +1,12 @@
+module.exports = {
+    AttributeDefinitions: [
+        {AttributeName: 'id', AttributeType: 'S'}
+    ],
+    KeySchema: [
+        {AttributeName: 'id', KeyType: 'HASH'}
+    ],
+    ProvisionedThroughput: {
+        ReadCapacityUnits: 1,
+        WriteCapacityUnits: 1
+    }
+};


### PR DESCRIPTION
Replaces the old node-kcl function with a function intended to be run via AWS Lambda. Also makes adjustments to documentation and tests to support this change.