### PR TITLE
incremental backup to S3 via dynamo streams + lambda

### DIFF
--- a/cloudformation/travis-dynamodb-replicator.template
+++ b/cloudformation/travis-dynamodb-replicator.template
@@ -24,7 +24,8 @@
                                     ],
                                     "Action": [
                                         "s3:PutObject",
-                                        "s3:GetObject"
+                                        "s3:GetObject",
+                                        "s3:DeleteObject"
                                     ],
                                     "Effect": "Allow"
                                 },

--- a/index.js
+++ b/index.js
@@ -1,9 +1,13 @@
 var AWS = require('aws-sdk');
 var queue = require('queue-async');
 var streambot = require('streambot');
+var crypto = require('crypto');
+var s3 = new AWS.S3();
 
-module.exports = replicate;
-module.exports.streambot = streambot(replicate);
+module.exports.replicate = replicate;
+module.exports.streambotReplicate = streambot(replicate);
+module.exports.backup = incrementalBackup;
+module.exports.streambotBackup = streambot(incrementalBackup);
 
 function replicate(event, callback) {
     console.log('Env: %s', JSON.stringify(process.env));
@@ -45,4 +49,55 @@ function processChange(change, replica, callback) {
             Key: change.Dynamodb.Keys
         }, callback);
     }
+}
+
+function incrementalBackup(event, callback) {
+    console.log('Env: %s', JSON.stringify(process.env));
+
+    var allRecords = event.Records.reduce(function(allRecords, action) {
+        var id = JSON.stringify(action.Dynamodb.Keys);
+
+        allRecords[id] = allRecords[id] || [];
+        allRecords[id].push(action);
+        return allRecords;
+    }, {});
+
+    var q = queue();
+
+    Object.keys(allRecords).forEach(function(key) {
+        q.defer(backupRecord, allRecords[key]);
+    });
+
+    q.awaitAll(function(err) {
+        if (err) throw err;
+        callback();
+    });
+}
+
+function backupRecord(changes, callback) {
+    var q = queue(1);
+
+    changes.forEach(function(change) {
+        q.defer(function(next) {
+            var id = crypto.createHash('md5')
+                .update(JSON.stringify(change.Dynamodb.Keys))
+                .digest('hex');
+
+            var table = change.eventSourceARN.split('/')[1];
+
+            var params = {
+                Bucket: process.env.BackupBucket,
+                Key: [process.env.BackupPrefix, table, id].join('/')
+            };
+
+            console.log('Backing up %s to %j', change.EventName, change.Dynamodb.Keys);
+            
+            var req = change.EventName === 'REMOVE' ? 'deleteObject' : 'putObject';
+            if (req === 'putObject') params.Body = JSON.stringify(change.Dynamodb.NewImage);
+
+            s3[req](params, next);
+        });
+    });
+
+    q.awaitAll(callback);
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,8 +5,13 @@ var replica = DynamoDB(test, 'mapbox-replicator', tableDef);
 var Dyno = require('dyno');
 var path = require('path');
 var events = path.resolve(__dirname, 'fixtures', 'events');
-var replicate = require('..');
+var replicate = require('..').replicate;
+var backup = require('..').backup;
 var _ = require('underscore');
+var crypto = require('crypto');
+var AWS = require('aws-sdk');
+var s3 = new AWS.S3();
+var queue = require('queue-async');
 
 replica.start();
 
@@ -23,8 +28,9 @@ process.env.ReplicaRegion = 'mock';
 process.env.ReplicaEndpoint = 'http://localhost:4567';
 process.env.AWS_ACCESS_KEY_ID = 'mock';
 process.env.AWS_SECRET_ACCESS_KEY = 'mock';
+process.env.BackupBucket = 'mapbox';
 
-replica.test('[lambda] insert', function(assert) {
+replica.test('[replicate] insert', function(assert) {
     var event = require(path.join(events, 'insert.json'));
     replicate(event, function(err) {
         assert.ifError(err, 'success');
@@ -36,7 +42,7 @@ replica.test('[lambda] insert', function(assert) {
     });
 });
 
-replica.test('[lambda] insert & modify', function(assert) {
+replica.test('[replicate] insert & modify', function(assert) {
     var event = require(path.join(events, 'insert-modify.json'));
     replicate(event, function(err) {
         assert.ifError(err, 'success');
@@ -48,7 +54,7 @@ replica.test('[lambda] insert & modify', function(assert) {
     });
 });
 
-replica.test('[lambda] insert, modify & delete', function(assert) {
+replica.test('[replicate] insert, modify & delete', function(assert) {
     var event = require(path.join(events, 'insert-modify-delete.json'));
     replicate(event, function(err) {
         assert.ifError(err, 'success');
@@ -60,7 +66,7 @@ replica.test('[lambda] insert, modify & delete', function(assert) {
     });
 });
 
-replica.test('[lambda] adjust many', function(assert) {
+replica.test('[replicate] adjust many', function(assert) {
     var event = require(path.join(events, 'adjust-many.json'));
     replicate(event, function(err) {
         assert.ifError(err, 'success');
@@ -81,6 +87,139 @@ replica.test('[lambda] adjust many', function(assert) {
                 'adjusted many records correctly'
             );
 
+            assert.end();
+        });
+    });
+});
+
+test('[incremental backup] insert', function(assert) {
+    process.env.BackupPrefix = 'dynamodb-replicator/test/' + crypto.randomBytes(4).toString('hex');
+
+    var event = require(path.join(events, 'insert.json'));
+    var table = event.Records[0].eventSourceARN.split('/')[1];
+    var id = crypto.createHash('md5')
+        .update(JSON.stringify(event.Records[0].Dynamodb.Keys))
+        .digest('hex');
+
+    backup(event, function(err) {
+        assert.ifError(err, 'success');
+
+        s3.getObject({
+            Bucket: process.env.BackupBucket,
+            Key: [process.env.BackupPrefix, table, id].join('/')
+        }, function(err, data) {
+            assert.ifError(err, 'no S3 error');
+            assert.ok(data.Body, 'got S3 object');
+
+            var found = JSON.parse(data.Body.toString());
+            var expected = { range: { N:'1' }, id: { S: 'record-1' } };
+            assert.deepEqual(found, expected, 'expected item put to S3');
+            assert.end();
+        });
+    });
+});
+
+test('[incremental backup] insert & modify', function(assert) {
+    process.env.BackupPrefix = 'dynamodb-replicator/test/' + crypto.randomBytes(4).toString('hex');
+
+    var event = require(path.join(events, 'insert-modify.json'));
+    var table = event.Records[0].eventSourceARN.split('/')[1];
+    var id = crypto.createHash('md5')
+        .update(JSON.stringify(event.Records[0].Dynamodb.Keys))
+        .digest('hex');
+
+    backup(event, function(err) {
+        assert.ifError(err, 'success');
+
+        s3.getObject({
+            Bucket: process.env.BackupBucket,
+            Key: [process.env.BackupPrefix, table, id].join('/')
+        }, function(err, data) {
+            assert.ifError(err, 'no S3 error');
+            assert.ok(data.Body, 'got S3 object');
+
+            var found = JSON.parse(data.Body.toString());
+            var expected = { range: { N:'2' }, id: { S: 'record-1' } };
+            assert.deepEqual(found, expected, 'expected item modified on S3');
+            assert.end();
+        });
+    });
+});
+
+test('[incremental backup] insert, modify & delete', function(assert) {
+    process.env.BackupPrefix = 'dynamodb-replicator/test/' + crypto.randomBytes(4).toString('hex');
+
+    var event = require(path.join(events, 'insert-modify-delete.json'));
+    var table = event.Records[0].eventSourceARN.split('/')[1];
+    var id = crypto.createHash('md5')
+        .update(JSON.stringify(event.Records[0].Dynamodb.Keys))
+        .digest('hex');
+
+    backup(event, function(err) {
+        assert.ifError(err, 'success');
+
+        s3.getObject({
+            Bucket: process.env.BackupBucket,
+            Key: [process.env.BackupPrefix, table, id].join('/')
+        }, function(err, data) {
+            assert.equal(err.code, 'NoSuchKey', 'object was deleted');
+            assert.end();
+        });
+    });
+});
+
+test('[incremental backup] adjust many', function(assert) {
+    process.env.BackupPrefix = 'dynamodb-replicator/test/' + crypto.randomBytes(4).toString('hex');
+
+    var event = require(path.join(events, 'adjust-many.json'));
+    var table = event.Records[0].eventSourceARN.split('/')[1];
+
+    var expected = [
+        { range: { N: '22' }, id: { S: 'record-2' } },
+        { range: { N: '33' }, id: { S: 'record-3' } }
+    ];
+
+    backup(event, function(err) {
+        assert.ifError(err, 'success');
+        var q = queue();
+
+        expected.forEach(function(record) {
+            q.defer(function(next) {
+                var key = { id: record.id };
+                var id = crypto.createHash('md5')
+                    .update(JSON.stringify(key))
+                    .digest('hex');
+
+                s3.getObject({
+                    Bucket: process.env.BackupBucket,
+                    Key: [process.env.BackupPrefix, table, id].join('/')
+                }, function(err, data) {
+                    assert.ifError(err, 'no S3 error for ' + JSON.stringify(key));
+                    if (!data) return next();
+                    assert.ok(data.Body, 'got S3 object for ' + JSON.stringify(key));
+
+                    var found = JSON.parse(data.Body.toString());
+                    assert.deepEqual(found, record, 'expected item modified on S3 for ' + JSON.stringify(key));
+                    next();
+                });
+            });
+        });
+
+        q.defer(function(next) {
+            var id = crypto.createHash('md5')
+                .update(JSON.stringify({ id: { S: 'record-1' } }))
+                .digest('hex');
+
+            s3.getObject({
+                Bucket: process.env.BackupBucket,
+                Key: [process.env.BackupPrefix, table, id].join('/')
+            }, function(err, data) {
+                assert.equal(err.code, 'NoSuchKey', 'object was deleted');
+                next();
+            });
+        });
+
+        q.awaitAll(function() {
             assert.end();
         });
     });


### PR DESCRIPTION
Adds a function that can be used to incrementally back up on S3 all changes that are provided by a DynamoDB stream. This could get really interesting in combination with a versioned S3 bucket.

Adjusts the `exports` on index.js in a not-backwards-compatible kind of way.