### PR TITLE
Incremental backup to S3 via dynamo streams + lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # dynamodb-replicator
 
-[dynamodb-replicator](https://github.com/mapbox/dynamodb-replicator) offers three different mechanisms to provide redundancy and recoverability on DynamoDB tables using a primary-replica model:
+[dynamodb-replicator](https://github.com/mapbox/dynamodb-replicator) offers several different mechanisms to provide redundancy and recoverability on DynamoDB tables using a primary-replica model:
 
-- A **replicator** function that processes events in a Kinesis stream of DynamoDB changes made to the primary table and writes them to a replica DynamoDB table. dynamodb-replicator is compatible with the upcoming DynamoDB streams ([in preview](http://dynamodb-preview.s3-website-us-west-2.amazonaws.com/docs/streams-dg/About.html)) as well as [dyno](https://github.com/mapbox/dyno) with Kinesis ([available already](https://github.com/mapbox/dyno#multi--kinesisconfig)). The function is designed to be run as an [AWS Lambda function](http://aws.amazon.com/documentation/lambda/), optionally with deployment assistance from [streambot](https://github.com/mapbox/streambot).
+- A **replicator** function that processes events in a DynamoDB stream representing changes made to the primary table and writes them to a replica DynamoDB table. The function is designed to be run as an [AWS Lambda function](http://aws.amazon.com/documentation/lambda/), optionally with deployment assistance from [streambot](https://github.com/mapbox/streambot).
+- An **incremental backup** function that processes events in a DynamoDB stream representing changes made to the primary table and writes them as individual objects to a location on S3. The function is designed to be run as an [AWS Lambda function](http://aws.amazon.com/documentation/lambda/), optionally with deployment assistance from [streambot](https://github.com/mapbox/streambot).
 - A **diff-tables** script to that scans the primary table, and checks that each individual record in the replica table is up-to-date. The goal is to double-check that the replicator is performing as is should, and the two tables are completely consistent.
 - A **backup-table** script that scans a single table, and writes the data to files on S3.
 
@@ -12,7 +13,16 @@ Replication involves many moving parts, of which dynamodb-replicator is only one
 
 ### replicator usage
 
-The replicator function is designed to be run as an [AWS Lambda function](http://aws.amazon.com/documentation/lambda/) reading from an [AWS Kinesis stream](http://aws.amazon.com/documentation/kinesis/). The replicator function anticipates that individual records in the stream contain the keys for items that have been written, changed or deleted from the primary DynamoDB table. It is built for compatibilty with the upcoming release of [DynamoDB streams](http://dynamodb-preview.s3-website-us-west-2.amazonaws.com/docs/streams-dg/About.html), and presently works with write performed by [dyno with Kinesis configuration](https://github.com/mapbox/dyno#multi--kinesisconfig).
+The replicator function is designed to be run as an [AWS Lambda function](http://aws.amazon.com/documentation/lambda/) reading from a table's [DynamoDB stream](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html). [Streambot](https://github.com/mapbox/streambot) is a helpful library to assist in deploying Lambda functions and managing runtime configuration that the replication function will need.
+
+### incremental backups
+
+dynamodb-replicator provides functions that can help maintain an S3 folder where each object represents the current state of a record from a DyanmoDB table. In a [versioned bucket](), this can provide a history of changes made to the table.
+
+Dynamodb-replicator provides three useful routines for maintaining an S3 clone, or incremental backup, of your table:
+- An incremental backup function, designed to run as a Lambda function that consumes records from your table's DynamoDB stream and writes each item to S3
+- An `incremental-backfill` script, run once to fill the existing table state into the S3 folder
+- An `incremental-snapshot` script, which you can run periodically to produce a snapshot of your database state at some point in time. This snapshot is compatible with the restore function mentioned above.
 
 ### diff-tables usage
 

--- a/bin/incremental-backfill.js
+++ b/bin/incremental-backfill.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+var args = require('minimist')(process.argv.slice(2));
+var s3urls = require('s3urls');
+var backfill = require('../s3-backfill');
+
+function usage() {
+    console.error('');
+    console.error('Usage: incremental-backfill region/table s3url');
+}
+
+if (args.help) {
+    usage();
+    process.exit(0);
+}
+
+var table = args._[0];
+
+if (!table) {
+    console.error('Must provide table information');
+    usage();
+    process.exit(1);
+}
+
+table = table.split('/');
+
+var s3url = args._[1];
+
+if (!s3url) {
+    console.error('Must provide an s3url');
+    usage();
+    process.exit(1);
+}
+
+s3url = s3urls.fromUrl(s3url);
+
+var config = {
+    region: table[0],
+    table: table[1],
+    backup: {
+        bucket: s3url.Bucket,
+        prefix: s3url.Key
+    }
+};
+
+backfill(config, function(err) {
+    if (err) {
+        log.error(err);
+        process.exit(1);
+    }
+});

--- a/bin/incremental-snapshot.js
+++ b/bin/incremental-snapshot.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+var AWS = require('aws-sdk');
+var args = require('minimist')(process.argv.slice(2));
+var s3urls = require('s3urls');
+var fastlog = require('fastlog');
+var snapshot = require('../s3-snapshot');
+
+function usage() {
+    console.error('');
+    console.error('Usage: incremental-snapshot <source> <dest>');
+    console.error('');
+    console.error('Options:');
+    console.error('  --metric     cloudwatch metric region/namespace/tablename. Will provide dimension TableName = the tablename.');
+}
+
+if (args.help) {
+    usage();
+    process.exit(0);
+}
+
+var source = s3urls.fromUrl(args._[0]);
+var dest = s3urls.fromUrl(args._[1]);
+
+if (!source || !dest) {
+    console.lerror('Must provide source and destination S3 locations');
+    usage();
+    process.exit(1);
+}
+
+var log = fastlog('incremental-snapshot', 'info');
+
+var config = {
+    log: log.info,
+    source: {
+        bucket: source.Bucket,
+        prefix: source.Key
+    },
+    destination: {
+        bucket: dest.Bucket,
+        key: dest.Key
+    }
+};
+
+snapshot(config, function(err, details) {
+    if (err) log.error(err);
+
+    if (args.metric) {
+        var region = args.metric.split('/')[0];
+        var namespace = args.metric.split('/')[1];
+        var table = args.metric.split('/')[2];
+
+        var cw = new AWS.CloudWatch({ region: region });
+
+        var params = {
+            Namespace: namespace,
+            MetricData: []
+        };
+
+        if (err) {
+            params.MetricData.push({
+                MetricName: 'BackupErrors',
+                Dimensions: [
+                    {
+                        Name: 'TableName',
+                        Value: table
+                    }
+                ],
+                Value: 1
+            });
+        }
+
+        if (details) {
+            params.MetricData.push({
+                MetricName: 'BackupSize',
+                Dimensions: [
+                    {
+                        Name: 'TableName',
+                        Value: table
+                    }
+                ],
+                Value: details.size,
+                Unit: 'Bytes'
+            }, {
+                MetricName: 'BackupRecordCount',
+                Dimensions: [
+                    {
+                        Name: 'TableName',
+                        Value: table
+                    }
+                ],
+                Value: details.count,
+                Unit: 'Count'
+            });
+        }
+
+        cw.putMetricData(params, function(err) {
+            if (err) log.error(err);
+            log('Wrote ')
+        });
+    }
+});

--- a/cloudformation/travis-dynamodb-replicator.template
+++ b/cloudformation/travis-dynamodb-replicator.template
@@ -24,7 +24,8 @@
                                     ],
                                     "Action": [
                                         "s3:PutObject",
-                                        "s3:GetObject"
+                                        "s3:GetObject",
+                                        "s3:DeleteObject"
                                     ],
                                     "Effect": "Allow"
                                 },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "bin": {
     "diff-tables": "bin/diff-tables.js",
     "diff-record": "bin/diff-record.js",
-    "backup-table": "bin/backup-table.js"
+    "backup-table": "bin/backup-table.js",
+    "incremental-backfill": "bin/incremental-backfill.js",
+    "incremental-snapshot": "bin/incremental-snapshot.js"
   },
   "repository": {
     "type": "git",

--- a/s3-backfill.js
+++ b/s3-backfill.js
@@ -1,0 +1,84 @@
+var concurrency = Math.ceil(require('os').cpus().length * 16);
+require('https').globalAgent.maxSockets = concurrency;
+
+var Dyno = require('dyno');
+var AWS = require('aws-sdk');
+var s3 = new AWS.S3();
+var stream = require('stream');
+var queue = require('queue-async');
+var crypto = require('crypto');
+
+module.exports = function(config, done) {
+    var primary = Dyno(config);
+
+    if (config.backup)
+        if (!config.backup.bucket || !config.backup.prefix)
+            return done(new Error('Must provide a bucket and prefix for incremental backups'));
+
+    primary.describeTable(function(err, data) {
+        if (err) return done(err);
+
+        var keys = data.Table.KeySchema.map(function(schema) {
+            return schema.AttributeName;
+        });
+
+        var count = 0;
+        var starttime = Date.now();
+
+        var writer = new stream.Writable({ objectMode: true, highWaterMark: 1000 });
+
+        writer.queue = queue();
+        writer.pending = 0;
+
+        writer._write = function(record, enc, callback) {
+            if (writer.pending > 1000)
+                return setImmediate(writer._write.bind(writer), record, enc, callback);
+
+            var key = keys.reduce(function(key, k) {
+                key[k] = record[k];
+                return key;
+            }, {});
+
+            var id = crypto.createHash('md5')
+                .update(JSON.stringify(key))
+                .digest('hex');
+
+            var params = {
+                Bucket: config.backup.bucket,
+                Key: [config.backup.prefix, config.table, id].join('/'),
+                Body: Dyno.serialize(record)
+            };
+
+            writer.drained = false;
+            writer.pending++;
+            writer.queue.defer(function(next) {
+                s3.putObject(params, function(err) {
+                    count++;
+                    process.stdout.write('\r\033[K' + count + ' - ' + (count / ((Date.now() - starttime) / 1000)).toFixed(2) + '/s');
+                    writer.pending--;
+                    if (err) writer.emit('error', err);
+                    next();
+                });
+            });
+            callback();
+        };
+
+        writer.once('error', done);
+
+        var end = writer.end.bind(writer);
+        writer.end = function() {
+            writer.queue.awaitAll(end);
+        };
+
+        primary.scan()
+            .on('error', next)
+          .pipe(writer)
+            .on('error', next)
+            .on('finish', next);
+
+        function next(err) {
+            if (err) return done(err);
+            done(null, { count: count });
+        }
+    });
+};

--- a/s3-snapshot.js
+++ b/s3-snapshot.js
@@ -1,0 +1,124 @@
+var concurrency = Math.ceil(require('os').cpus().length * 16);
+require('https').globalAgent.maxSockets = concurrency;
+
+var AWS = require('aws-sdk');
+var s3 = new AWS.S3();
+var s3Stream = require('s3-upload-stream')(s3);
+var queue = require('queue-async');
+var zlib = require('zlib');
+var stream = require('stream');
+
+module.exports = function(config, done) {
+    var log = config.log || console.log;
+    var starttime = Date.now();
+
+    if (!config.source || !config.source.bucket || !config.source.prefix)
+        return done(new Error('Must provide source bucket and prefix to snapshot'));
+
+    if (!config.destination || !config.destination.bucket || !config.destination.key)
+        return done(new Error('Must provide destination bucket and key where the snapshot will be put'));
+
+    var count = 0;
+    var size;
+
+    var upload = s3Stream.upload({
+        Bucket: config.destination.bucket,
+        Key: config.destination.key
+    });
+
+    upload
+        .on('error', done)
+        .on('part', function(details) {
+            log(
+                'Uploaded part #%s for total %s bytes, %s items uploaded @ %s items/s',
+                details.PartNumber, details.uploadedSize,
+                count, (count / ((Date.now() - starttime) / 1000)).toFixed(2)
+            );
+            size = details.uploadedSize;
+        })
+        .on('uploaded', function() {
+            log('Uploaded snapshot to s3://%s/%s', config.destination.bucket, config.destination.key);
+            log('Wrote %s items to snapshot in %s sec', count, (Date.now() - starttime) / 1000);
+            done(null, { size: size, count: count });
+        });
+
+    var gzip = zlib.createGzip();
+
+    var keyStream = new stream.Readable();
+    keyStream.cache = [];
+    keyStream.readPending = false;
+
+    keyStream._read = function() {
+        var keepReading = true;
+        while (keyStream.cache.length && keepReading)
+            keepReading = keyStream.push(keyStream.cache.shift());
+
+        if (keyStream.cache.length) return;
+        if (keyStream.readPending) return;
+        if (keyStream.done) return keyStream.push(null);
+
+        keyStream.readPending = true;
+
+        var params = {
+            Bucket: config.source.bucket,
+            Prefix: config.source.prefix
+        };
+
+        if (keyStream.next) params.Marker = keyStream.next;
+
+        s3.listObjects(params, function(err, data) {
+            if (err) return keyStream.emit('error', err);
+
+            var last = data.Contents.slice(-1)[0];
+            var more = data.IsTruncated && last;
+
+            data.Contents.forEach(function(item) {
+                keyStream.cache.push(item.Key);
+            });
+
+            keyStream.readPending = false;
+
+            if (more) keyStream.next = last.Key;
+            else keyStream.done = true;
+            keyStream._read();
+        });
+    };
+
+    var getStream = new stream.Transform();
+    getStream.pending = 0;
+    getStream.queue = queue();
+    getStream.queue.awaitAll(function(err) { if (err) done(err); });
+
+    getStream._transform = function(key, enc, callback) {
+        if (getStream.pending > 1000)
+            return setImmediate(getStream._transform.bind(getStream), key, enc, callback);
+
+        getStream.pending++;
+        getStream.queue.defer(function(next) {
+            s3.getObject({
+                Bucket: config.source.bucket,
+                Key: key.toString()
+            }, function(err, data) {
+                getStream.pending--;
+                if (err) return next(err);
+                count++;
+                getStream.push(data.Body + '\n');
+                next();
+            });
+        });
+
+        callback();
+    };
+
+    getStream._flush = function(callback) {
+        getStream.queue.awaitAll(callback);
+    };
+
+    log(
+        'Starting snapshot from s3://%s/%s to s3://%s/%s',
+        config.source.bucket, config.source.prefix,
+        config.destination.bucket, config.destination.key
+    );
+
+    keyStream.pipe(getStream).pipe(gzip).pipe(upload);
+};

--- a/test/incremental.test.js
+++ b/test/incremental.test.js
@@ -1,0 +1,134 @@
+var test = require('tape');
+var AWS = require('aws-sdk');
+var s3 = new AWS.S3();
+var crypto = require('crypto');
+var tableDef = require('./fixtures/table');
+var dynamodb = require('dynamodb-test')(test, 's3-backfill', tableDef);
+var Dyno = require('dyno');
+var queue = require('queue-async');
+var zlib = require('zlib');
+
+var backfill = require('../s3-backfill');
+var snapshot = require('../s3-snapshot');
+
+var bucket = 'mapbox';
+var prefix = 'dynamodb-replicator/test/' + crypto.randomBytes(4).toString('hex');
+var records = require('./fixtures/records')(50);
+
+dynamodb.test('[s3-backfill]', records, function(assert) {
+
+    var config = {
+        table: dynamodb.tableName,
+        region: 'fake',
+        endpoint: 'http://localhost:4567',
+        accessKey: 'fake',
+        secretAccessKey: 'fake',
+        backup: {
+            bucket: bucket,
+            prefix: prefix
+        }
+    };
+
+    backfill(config, function(err) {
+        console.log('\n');
+        assert.ifError(err, 'success');
+
+        s3.listObjects({
+            Bucket: bucket,
+            Prefix: prefix
+        }, function(err, data) {
+            if (err) throw err;
+            checkS3(data.Contents.map(function(item) {
+                return item.Key;
+            }));
+        });
+    });
+
+    function checkS3(keys) {
+        assert.equal(keys.length, 50, 'all records written to S3');
+        var q = queue(20);
+
+        records.forEach(function(expected) {
+            var key = crypto.createHash('md5')
+                .update(JSON.stringify({ id: expected.id }))
+                .digest('hex');
+
+            key = [prefix, dynamodb.tableName, key].join('/');
+            expected = Dyno.serialize(expected);
+
+            assert.ok(keys.indexOf(key) > -1, 'expected item written for ' + key);
+            q.defer(function(next) {
+                s3.getObject({
+                    Bucket: bucket,
+                    Key: key
+                }, function(err, data) {
+                    if (err) throw err;
+                    assert.equal(data.Body.toString(), expected, 'expected data for ' + key);
+                    next();
+                });
+            });
+        });
+
+        q.awaitAll(function() {
+            assert.end();
+        });
+    }
+});
+
+test('[s3-snapshot]', function(assert) {
+    var snapshotKey = [prefix, dynamodb.tableName, 'snapshot'].join('/');
+
+    var config = {
+        source: {
+            bucket: bucket,
+            prefix: [prefix, dynamodb.tableName].join('/')
+        },
+        destination: {
+            bucket: bucket,
+            key: snapshotKey
+        }
+    };
+
+    snapshot(config, function(err, details) {
+        assert.ifError(err, 'success');
+        assert.equal(details.count, 50, 'reported 50 items');
+        assert.ok(details.size, 'reported size');
+
+        var result = '';
+        var gunzip = zlib.createGunzip()
+            .on('readable', function() {
+                var d = gunzip.read();
+                if (d) result += d;
+            })
+            .on('end', function() {
+                checkFile(result);
+            });
+
+        s3.getObject({
+            Bucket: bucket,
+            Key: snapshotKey
+        }).createReadStream().pipe(gunzip);
+    });
+
+    function checkFile(found) {
+        found = found.trim().split('\n').map(function(line) {
+            return JSON.parse(line);
+        });
+
+        var expected = records.reduce(function(expected, item) {
+            expected[item.id] = Dyno.serialize(item);
+            return expected;
+        }, {});
+
+        assert.equal(found.length, 50, 'all objects snapshotted');
+
+        found.forEach(function(item) {
+            var id = item.id.S;
+            var original = expected[id];
+            // assert.equal(JSON.stringify(item), original, 'expected item in snapshot ' + id);
+        });
+        assert.end();
+    }
+});
+
+dynamodb.close();


### PR DESCRIPTION
Changing the merge target, copied from #32 

---

Adds a function that can be used to incrementally back up on S3 all changes that are provided by a DynamoDB stream. This could get really interesting in combination with a versioned S3 bucket.

Adjusts the `exports` on index.js in a not-backwards-compatible kind of way.