### PR TITLE
Adjust handling of buffers that are encoded in stream records

### DIFF
--- a/test/fixtures/events/insert-buffer.json
+++ b/test/fixtures/events/insert-buffer.json
@@ -1,0 +1,55 @@
+{
+    "Records":[
+        {
+            "eventName":"INSERT",
+            "eventVersion":"1.0",
+            "eventSource":"aws:dynamodb",
+            "dynamodb": {
+                "NewImage":{
+                    "range": {
+                        "N": "1"
+                    },
+                    "id": {
+                        "S": "record-1"
+                    },
+                    "val": {
+                        "B": "aGVsbG8="
+                    },
+                    "map": {
+                        "M": {
+                            "prop": {
+                                "B": "aGVsbG8="
+                            }
+                        }
+                    },
+                    "list": {
+                        "L": [
+                            {
+                                "S": "string"
+                            },
+                            {
+                                "B": "aGVsbG8="
+                            }
+                        ]
+                    },
+                    "bufferSet": {
+                        "BS": [
+                            "aGVsbG8="
+                        ]
+                    }
+                },
+                "SizeBytes":26,
+                "StreamViewType":"NEW_AND_OLD_IMAGES",
+                "SequenceNumber":"111",
+                "Keys":{
+                    "id": {
+                        "S": "record-1"
+                    }
+                }
+            },
+            "eventID":"1",
+            "eventSourceARN":"arn:aws:dynamodb:us-east-1:123456789012:table/fake",
+            "awsRegion":"us-east-1"
+        }
+    ]
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -86,4 +86,33 @@ replica.test('[lambda] adjust many', function(assert) {
     });
 });
 
+replica.test('[lambda] insert with buffers', function(assert) {
+    var event = require(path.join(events, 'insert-buffer.json'));
+    replicate(event, function(err) {
+        assert.ifError(err, 'success');
+        dyno.scan(function(err, data) {
+            if (err) throw err;
+
+            var expected = {
+                range: 1,
+                id: 'record-1',
+                val: new Buffer('hello'),
+                map: { prop: new Buffer('hello') },
+                list: ['string', new Buffer('hello')],
+                bufferSet: Dyno.createSet([new Buffer('hello')], 'B')
+            };
+
+            data = data[0];
+
+            assert.equal(data.range, expected.range, 'expected range');
+            assert.equal(data.id, expected.id, 'expected id');
+            assert.deepEqual(data.val, expected.val, 'expected val');
+            assert.deepEqual(data.map, expected.map, 'expected map');
+            assert.deepEqual(data.list, expected.list, 'expected list');
+            assert.deepEqual(data.bufferSet.contents, expected.bufferSet.contents, 'expected bufferSet.contents');
+            assert.end();
+        });
+    });
+});
+
 replica.close();


### PR DESCRIPTION
DynamoDB `NewImage` represent binary data as base64-encoded strings. Handing these off to aws-sdk-js `putItem()` requests results in double-base64 encoding and replication errors.

cc @mick