### PR TITLE
Snapshot 404s

### DIFF
--- a/bin/incremental-snapshot.js
+++ b/bin/incremental-snapshot.js
@@ -96,7 +96,7 @@ snapshot(config, function(err, details) {
 
         cw.putMetricData(params, function(err) {
             if (err) log.error(err);
-            log('Wrote ')
+            else log.info('Wrote %s size / %s count metrics to %s', details.size, details.count, args.metric);
         });
     }
 });


### PR DESCRIPTION
The snapshot script performs a bunch of `listObjects` requests to build a backlog of keys to get. This insures that the `getObject` queue always has work to do, resulting in a faster snapshot of the incremental backup.

The problem is that an incremental backup is changing constantly. This means that a key might land in the `getObjects` backlog, and then be deleted from S3 before the `getObject` request is made. For that reason, `404`s from S3 are considered acceptable.