### PR TITLE
Incremental backup tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,37 @@ Options:
 # Aggregate all the items in an S3 folder into a single snapshot file
 $ incremental-snapshot s3://dynamodb-backups/incremental/primary s3://dynamodb-backups/snapshots/primary
 ```
+
+### incremental-diff-record
+
+Checks for consistency between a DynamoDB record and its backed-up version on S3.
+
+```
+$ npm install -g dynamodb-replicator
+$ bin/incremental-diff-record.js --help
+
+Usage: incremental-diff-record <tableinfo> <s3url> <recordkey>
+ - tableinfo: the table where the record lives, specified as `region/tablename`
+ - s3url: s3 folder where the incremental backups live
+ - recordkey: the key for the record specified as a JSON object
+
+# Check that a record is up-to-date in the incremental backup
+$ incremental-diff-record us-east-1/primary s3://dynamodb-backups/incremental/primary '{"id":"abc"}'
+```
+
+### incremental-backup-record
+
+Copies a DynamoDB record's present state to an incremental backup folder on S3.
+
+```
+$ npm install -g dynamodb-replicator
+$ bin/incremental-backup-record.js --help
+
+Usage: incremental-backup-record <tableinfo> <s3url> <recordkey>
+ - tableinfo: the table to backup from, specified as `region/tablename`
+ - s3url: s3 folder into which the record should be backed up to
+ - recordkey: the key for the record specified as a JSON object
+
+# Backup a single record to S3
+$ incremental-backup-record us-east-1/primary s3://dynamodb-backups/incremental/primary '{"id":"abc"}'
+```

--- a/bin/diff-record.js
+++ b/bin/diff-record.js
@@ -35,14 +35,6 @@ if (!key) {
     process.exit(1);
 }
 
-try { key = JSON.parse(key); }
-catch (err) {
-    console.error(key);
-    console.error('The key provided is not a valid JSON string');
-    usage();
-    process.exit(1);
-}
-
 // Converts incoming strings in wire or dyno format into dyno format
 try { key = Dyno.deserialize(key); }
 catch (err) { key = JSON.parse(key); }

--- a/bin/diff-record.js
+++ b/bin/diff-record.js
@@ -43,6 +43,10 @@ catch (err) {
     process.exit(1);
 }
 
+// Converts incoming strings in wire or dyno format into dyno format
+try { key = Dyno.deserialize(key); }
+catch (err) { key = JSON.parse(key); }
+
 var primaryConfig = {
     table: args.primary.split('/')[1],
     region: args.primary.split('/')[0]

--- a/bin/incremental-backup-record.js
+++ b/bin/incremental-backup-record.js
@@ -15,6 +15,11 @@ function usage() {
     console.error(' - recordkey: the key for the record specified as a JSON object');
 }
 
+if (args.help) {
+    usage();
+    process.exit(0);
+}
+
 var table = args._[0];
 
 if (!table) {

--- a/bin/incremental-backup-record.js
+++ b/bin/incremental-backup-record.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+var minimist = require('minimist');
+var s3urls = require('s3urls');
+var Dyno = require('dyno');
+var backup = require('..').backup;
+
+var args = minimist(process.argv.slice(2));
+
+function usage() {
+    console.error('');
+    console.error('Usage: incremental-backup-record <tableinfo> <s3url> <recordkey>');
+    console.error(' - tableinfo: the table to backup from, specified as `region/tablename`');
+    console.error(' - s3url: s3 folder into which the record should be backed up to');
+    console.error(' - recordkey: the key for the record specified as a JSON object');
+}
+
+var table = args._[0];
+
+if (!table) {
+    console.error('Must provide table information');
+    usage();
+    process.exit(1);
+}
+
+var region = table.split('/')[0];
+table = table.split('/')[1];
+
+var s3url = args._[1];
+
+if (!s3url) {
+    console.error('Must provide an s3url');
+    usage();
+    process.exit(1);
+}
+
+s3url = s3urls.fromUrl(s3url);
+process.env.BackupBucket = s3url.Bucket;
+process.env.BackupPrefix = s3url.Key;
+
+var key = args._[2];
+
+if (!key) {
+  console.error('Must provide a record key');
+  usage();
+  process.exit(1);
+}
+
+// Converts incoming strings in wire or dyno format into dyno format
+try { key = Dyno.deserialize(key); }
+catch (err) { key = JSON.parse(key); }
+
+var dyno = Dyno({
+  region: region,
+  table: table
+});
+
+dyno.getItem(key, function(err, data) {
+  if (err) throw err;
+
+  var event = {
+    Records: [
+      {
+        dynamodb: {
+          Keys: JSON.parse(Dyno.serialize(key)),
+          NewImage: data ? JSON.parse(Dyno.serialize(data)) : undefined
+        },
+        eventSourceARN: '/' + table,
+        eventName: data ? 'INSERT' : 'REMOVE'
+      }
+    ]
+  };
+
+  backup(event, function(err) {
+    if (err) throw err;
+  });
+});

--- a/bin/incremental-diff-record.js
+++ b/bin/incremental-diff-record.js
@@ -18,6 +18,11 @@ function usage() {
     console.error(' - recordkey: the key for the record specified as a JSON object');
 }
 
+if (args.help) {
+    usage();
+    process.exit(0);
+}
+
 var table = args._[0];
 
 if (!table) {

--- a/bin/incremental-diff-record.js
+++ b/bin/incremental-diff-record.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+var minimist = require('minimist');
+var s3urls = require('s3urls');
+var Dyno = require('dyno');
+var crypto = require('crypto');
+var AWS = require('aws-sdk');
+var s3 = new AWS.S3();
+var assert = require('assert');
+
+var args = minimist(process.argv.slice(2));
+
+function usage() {
+    console.error('');
+    console.error('Usage: incremental-diff-record <tableinfo> <s3url> <recordkey>');
+    console.error(' - tableinfo: the table where the record lives, specified as `region/tablename`');
+    console.error(' - s3url: s3 folder where the incremental backups live');
+    console.error(' - recordkey: the key for the record specified as a JSON object');
+}
+
+var table = args._[0];
+
+if (!table) {
+    console.error('Must provide table information');
+    usage();
+    process.exit(1);
+}
+
+var region = table.split('/')[0];
+table = table.split('/')[1];
+
+var s3url = args._[1];
+
+if (!s3url) {
+    console.error('Must provide an s3url');
+    usage();
+    process.exit(1);
+}
+
+s3url = s3urls.fromUrl(s3url);
+
+var key = args._[2];
+
+if (!key) {
+  console.error('Must provide a record key');
+  usage();
+  process.exit(1);
+}
+
+// Converts incoming strings in wire or dyno format into dyno format
+try { key = Dyno.deserialize(key); }
+catch (err) { key = JSON.parse(key); }
+
+s3url.Key = [
+  s3url.Key,
+  table,
+  crypto.createHash('md5')
+    .update(Dyno.serialize(key))
+    .digest('hex')
+].join('/');
+
+var dyno = Dyno({
+  region: region,
+  table: table
+});
+
+dyno.getItem(key, function(err, dynamoRecord) {
+  if (err) throw err;
+
+  s3.getObject(s3url, function(err, data) {
+    if (err && err.statusCode !== 404) throw err;
+    var s3data = err ? undefined : Dyno.deserialize(data.Body.toString());
+
+    console.log('DynamoDB record');
+      console.log('--------------');
+      console.log(dynamoRecord);
+      console.log('');
+
+      console.log('Incremental backup record');
+      console.log('--------------');
+      console.log(s3data);
+      console.log('');
+
+      try {
+        assert.deepEqual(s3data, dynamoRecord);
+        console.log('----------------------------');
+        console.log('✔ The records are equivalent');
+        console.log('----------------------------');
+      }
+      catch (err) {
+        console.log('--------------------------------');
+        console.log('✘ The records are not equivalent');
+        console.log('--------------------------------');
+      }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "diff-record": "bin/diff-record.js",
     "backup-table": "bin/backup-table.js",
     "incremental-backfill": "bin/incremental-backfill.js",
-    "incremental-snapshot": "bin/incremental-snapshot.js"
+    "incremental-snapshot": "bin/incremental-snapshot.js",
+    "incremental-backup-record": "bin/incremental-backup-record.js",
+    "incremental-diff-record": "bin/incremental-diff-record.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- adjusts logging so that Lambda invocations are more clear about what work they should do vs. what they actually accomplished. Useful in error/timeout cases.
- adds a CLI tool that diffs records between a table and an S3 incremental backup
- adds a CLI tool to backup the present state of a single record to S3
- adjusts the table vs. table diff-record script so that you can pass it wire-formatted JSON keys