### PR TITLE
Backfill wire-format key ==> s3 id

### DIFF
--- a/s3-backfill.js
+++ b/s3-backfill.js
@@ -40,7 +40,7 @@ module.exports = function(config, done) {
             }, {});
 
             var id = crypto.createHash('md5')
-                .update(JSON.stringify(key))
+                .update(Dyno.serialize(key))
                 .digest('hex');
 
             var params = {

--- a/test/incremental.test.js
+++ b/test/incremental.test.js
@@ -50,7 +50,7 @@ dynamodb.test('[s3-backfill]', records, function(assert) {
 
         records.forEach(function(expected) {
             var key = crypto.createHash('md5')
-                .update(JSON.stringify({ id: expected.id }))
+                .update(Dyno.serialize({ id: expected.id }))
                 .digest('hex');
 
             key = [prefix, dynamodb.tableName, key].join('/');


### PR DESCRIPTION
Fixes a bug where the backfill scripts wrote incremental backup files to the wrong S3 location.