### PR TITLE
Improved lambda logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,22 +9,33 @@ module.exports.streambotReplicate = streambot(replicate);
 module.exports.backup = incrementalBackup;
 module.exports.streambotBackup = streambot(incrementalBackup);
 
-function replicate(event, callback) {
-    console.log('Env: %s', JSON.stringify(process.env));
+function printRemaining(events, first) {
+    var msg = '--> %s events remaining';
+    if (first) msg = msg.replace('remaining', 'total');
 
+    console.log(msg, Object.keys(events).length);
+    Object.keys(events).forEach(function(hash) {
+        console.log('%s: %s %s', hash, events[hash].action, events[hash].key);
+    });
+}
+
+function replicate(event, callback) {
     var replicaConfig = { region: process.env.ReplicaRegion };
     if (process.env.ReplicaEndpoint) replicaConfig.endpoint = process.env.ReplicaEndpoint;
     var replica = new AWS.DynamoDB(replicaConfig);
 
+    var events = {};
     var allRecords = event.Records.reduce(function(allRecords, action) {
         var id = JSON.stringify(action.dynamodb.Keys);
+        var hash = crypto.createHash('md5').update(id).digest('hex');
+        events[hash] = { key: id, action: action.eventName };
 
         allRecords[id] = allRecords[id] || [];
         allRecords[id].push(action);
         return allRecords;
     }, {});
 
-    console.log('%s effected keys: %s', Object.keys(allRecords).length, Object.keys(allRecords));
+    printRemaining(events, true);
 
     var q = queue();
 
@@ -34,69 +45,75 @@ function replicate(event, callback) {
     });
 
     q.awaitAll(callback);
-}
 
-function processChange(change, replica, callback) {
-    if (change.eventName === 'INSERT' || change.eventName === 'MODIFY') {
-        var newItem = (function decodeBuffers(obj) {
-            if (typeof obj !== 'object') return obj;
+    function processChange(change, replica, next) {
+        var id = JSON.stringify(change.dynamodb.Keys);
+        var hash = crypto.createHash('md5').update(id).digest('hex');
 
-            return Object.keys(obj).reduce(function(newObj, key) {
-                var value = obj[key];
+        if (change.eventName === 'INSERT' || change.eventName === 'MODIFY') {
+            var newItem = (function decodeBuffers(obj) {
+                if (typeof obj !== 'object') return obj;
 
-                if (key === 'B' && typeof value === 'string')
-                    newObj[key] = new Buffer(value, 'base64');
+                return Object.keys(obj).reduce(function(newObj, key) {
+                    var value = obj[key];
 
-                else if (key === 'BS' && Array.isArray(value))
-                    newObj[key] = value.map(function(encoded) {
-                        return new Buffer(encoded, 'base64');
-                    });
+                    if (key === 'B' && typeof value === 'string')
+                        newObj[key] = new Buffer(value, 'base64');
 
-                else if (Array.isArray(value))
-                    newObj[key] = value.map(decodeBuffers);
+                    else if (key === 'BS' && Array.isArray(value))
+                        newObj[key] = value.map(function(encoded) {
+                            return new Buffer(encoded, 'base64');
+                        });
 
-                else if (typeof value === 'object')
-                    newObj[key] = decodeBuffers(value);
+                    else if (Array.isArray(value))
+                        newObj[key] = value.map(decodeBuffers);
 
-                else
-                    newObj[key] = value;
+                    else if (typeof value === 'object')
+                        newObj[key] = decodeBuffers(value);
 
-                return newObj;
-            }, {});
-        })(change.dynamodb.NewImage);
+                    else
+                        newObj[key] = value;
 
-        replica.putItem({
-            TableName: process.env.ReplicaTable,
-            Item: newItem
-        }, function(err) {
-            if (err) return callback(err);
-            console.log('Replicated %s to %j', change.eventName, change.dynamodb.Keys);
-            callback();
-        });
-    } else if (change.eventName === 'REMOVE') {
-        replica.deleteItem({
-            TableName: process.env.ReplicaTable,
-            Key: change.dynamodb.Keys
-        }, function(err) {
-            if (err) return callback(err);
-            console.log('Replicated %s to %j', change.eventName, change.dynamodb.Keys);
-            callback();
-        });
+                    return newObj;
+                }, {});
+            })(change.dynamodb.NewImage);
+
+            replica.putItem({
+                TableName: process.env.ReplicaTable,
+                Item: newItem
+            }, function(err) {
+                if (err) return next(err);
+                delete events[hash];
+                printRemaining(events);
+                next();
+            });
+        } else if (change.eventName === 'REMOVE') {
+            replica.deleteItem({
+                TableName: process.env.ReplicaTable,
+                Key: change.dynamodb.Keys
+            }, function(err) {
+                if (err) return next(err);
+                delete events[hash];
+                printRemaining(events);
+                next();
+            });
+        }
     }
 }
 
 function incrementalBackup(event, callback) {
-    console.log('Env: %s', JSON.stringify(process.env));
-
+    var events = {};
     var allRecords = event.Records.reduce(function(allRecords, action) {
         var id = JSON.stringify(action.dynamodb.Keys);
+        var hash = crypto.createHash('md5').update(action.eventName + id).digest('hex');
+        events[hash] = { key: id, action: action.eventName };
 
         allRecords[id] = allRecords[id] || [];
         allRecords[id].push(action);
         return allRecords;
     }, {});
 
-    console.log('%s effected keys: %s', Object.keys(allRecords).length, Object.keys(allRecords));
+    printRemaining(events, true);
 
     var q = queue();
 
@@ -108,34 +125,38 @@ function incrementalBackup(event, callback) {
         if (err) throw err;
         callback();
     });
-}
 
-function backupRecord(changes, callback) {
-    var q = queue(1);
+    function backupRecord(changes, callback) {
+        var q = queue(1);
 
-    changes.forEach(function(change) {
-        q.defer(function(next) {
-            var id = crypto.createHash('md5')
-                .update(JSON.stringify(change.dynamodb.Keys))
-                .digest('hex');
+        changes.forEach(function(change) {
+            q.defer(function(next) {
+                var id = crypto.createHash('md5')
+                    .update(JSON.stringify(change.dynamodb.Keys))
+                    .digest('hex');
+                var changeId = crypto.createHash('md5')
+                    .update(change.eventName + JSON.stringify(change.dynamodb.Keys))
+                    .digest('hex');
 
-            var table = change.eventSourceARN.split('/')[1];
+                var table = change.eventSourceARN.split('/')[1];
 
-            var params = {
-                Bucket: process.env.BackupBucket,
-                Key: [process.env.BackupPrefix, table, id].join('/')
-            };
+                var params = {
+                    Bucket: process.env.BackupBucket,
+                    Key: [process.env.BackupPrefix, table, id].join('/')
+                };
 
-            var req = change.eventName === 'REMOVE' ? 'deleteObject' : 'putObject';
-            if (req === 'putObject') params.Body = JSON.stringify(change.dynamodb.NewImage);
+                var req = change.eventName === 'REMOVE' ? 'deleteObject' : 'putObject';
+                if (req === 'putObject') params.Body = JSON.stringify(change.dynamodb.NewImage);
 
-            s3[req](params, function(err) {
-                if (err) return next(err);
-                console.log('Backed up %s to %j', change.eventName, change.dynamodb.Keys);
-                next();
+                s3[req](params, function(err) {
+                    if (err) return next(err);
+                    delete events[changeId];
+                    printRemaining(events);
+                    next();
+                });
             });
         });
-    });
 
-    q.awaitAll(callback);
+        q.awaitAll(callback);
+    }
 }


### PR DESCRIPTION
Refs #40 

Basically, this prints a list of the relevant events that are going to be processed at the beginning of the invocation (either backup or replication). Each time an event is processed successfully, it drops one item off the list and prints the remaining items. This yields a log that looks something like this:

```
--> 3 events total
b0f114ec65d10eee21104acf9eb2e8cb: INSERT {"id":{"S":"record-1"}}
bce74c933655812e62008a599f129238: MODIFY {"id":{"S":"record-1"}}
01f6e033f46363c08a8af9b4406ebfc5: REMOVE {"id":{"S":"record-1"}}
--> 2 events remaining
bce74c933655812e62008a599f129238: MODIFY {"id":{"S":"record-1"}}
01f6e033f46363c08a8af9b4406ebfc5: REMOVE {"id":{"S":"record-1"}}
--> 1 events remaining
01f6e033f46363c08a8af9b4406ebfc5: REMOVE {"id":{"S":"record-1"}}
--> 0 events remaining
```

If an invocation fails, the hash (e.g. `b0f114ec65d10eee21104acf9eb2e8cb`) is a great thing to search subsequent logs for in order to prove that the event was retried and completed later.

cc @emilymcafee @willwhite 
