### PR TITLE
Snapshot no-op on 404

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "minimist": "^1.1.0",
     "queue-async": "^1.0.7",
     "s3-upload-stream": "^1.0.7",
-    "s3scan": "0.0.2",
+    "s3scan": "0.0.4",
     "s3urls": "^1.3.0",
     "split": "^0.3.3",
     "streambot": "^3.1.0",


### PR DESCRIPTION
When running a snapshot over an incremental S3 backup, there will be an unknown lag between when an object's key is listed and when a getObject request is made to push the data into the snapshot. If the object is deleted in the meantime, the resulting 404 should be ignored.