### PR TITLE
Configurable retries and logger on snapshot

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "minimist": "^1.1.0",
     "queue-async": "^1.0.7",
     "s3-upload-stream": "^1.0.7",
-    "s3scan": "0.0.4",
+    "s3scan": "0.0.7",
     "s3urls": "^1.3.0",
     "split": "^0.3.3",
     "streambot": "^3.1.0",


### PR DESCRIPTION
Allows the caller to specify:
- max retries that will be made should S3 encounter a retryable error
- log file location for detailed logging of all the S3 requests made by the snapshot process