### PR TITLE
Improved cli tools for interacting with incremental backups

### DIFF
--- a/bin/incremental-diff-record.js
+++ b/bin/incremental-diff-record.js
@@ -52,6 +52,13 @@ if (!key) {
   process.exit(1);
 }
 
+// Sort the attributes in the provided key
+key = JSON.parse(key);
+key = JSON.stringify(Object.keys(key).sort().reduce(function(keyObj, attr) {
+  keyObj[attr] = key[attr];
+  return keyObj;
+}, {}));
+
 // Converts incoming strings in wire or dyno format into dyno format
 try { key = Dyno.deserialize(key); }
 catch (err) { key = JSON.parse(key); }
@@ -81,7 +88,7 @@ dyno.getItem(key, function(err, dynamoRecord) {
       console.log(dynamoRecord);
       console.log('');
 
-      console.log('Incremental backup record');
+      console.log('Incremental backup record (%s)', s3url.Key);
       console.log('--------------');
       console.log(s3data);
       console.log('');

--- a/bin/incremental-record-history.js
+++ b/bin/incremental-record-history.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+var minimist = require('minimist');
+var s3urls = require('s3urls');
+var crypto = require('crypto');
+var AWS = require('aws-sdk');
+var s3 = new AWS.S3();
+var queue = require('queue-async');
+var Dyno = require('dyno');
+
+var args = minimist(process.argv.slice(2));
+
+function usage() {
+    console.error('');
+    console.error('Usage: incremental-record-history <tableinfo> <s3url> <recordkey>');
+    console.error(' - tableinfo: the table where the record lives, specified as `region/tablename`');
+    console.error(' - s3url: s3 folder where the incremental backups live. Table name will be appended');
+    console.error(' - recordkey: the key for the record specified as a JSON object');
+}
+
+if (args.help) {
+    usage();
+    process.exit(0);
+}
+
+var table = args._[0];
+
+if (!table) {
+    console.error('Must provide table information');
+    usage();
+    process.exit(1);
+}
+
+var region = table.split('/')[0];
+table = table.split('/')[1];
+
+var s3url = args._[1];
+
+if (!s3url) {
+    console.error('Must provide an s3url');
+    usage();
+    process.exit(1);
+}
+
+s3url = s3urls.fromUrl(s3url);
+
+var key = args._[2];
+
+if (!key) {
+  console.error('Must provide a record key');
+  usage();
+  process.exit(1);
+}
+
+// Sort the attributes in the provided key
+key = JSON.parse(key);
+key = JSON.stringify(Object.keys(key).sort().reduce(function(keyObj, attr) {
+  keyObj[attr] = key[attr];
+  return keyObj;
+}, {}));
+
+// Converts incoming strings in wire or dyno format into dyno format
+try { key = Dyno.deserialize(key); }
+catch (err) { key = JSON.parse(key); }
+
+s3url.Key = [
+  s3url.Key,
+  table,
+  crypto.createHash('md5')
+    .update(Dyno.serialize(key))
+    .digest('hex')
+].join('/');
+
+var q = queue();
+q.awaitAll(function(err, results) {
+  if (err) throw err;
+  if (!results.length) return;
+  results.sort(function(a, b) { return b.date - a.date }).forEach(function(version) {
+    console.log('\nModified: %s', version.date.toISOString());
+    console.log('----------------------------------');
+    console.log((typeof version.data === 'string' ? version.data : JSON.stringify(version.data, null, 2)) + '\n');
+  });
+});
+
+(function listVersions(next) {
+  var params = {
+    Bucket: s3url.Bucket,
+    Prefix: s3url.Key
+  };
+
+  if (next) params.VersionIdMarker = next;
+
+  s3.listObjectVersions(params, function(err, data) {
+    if (err) throw err;
+
+    data.Versions.forEach(function(version) {
+      q.defer(function(next) {
+        s3.getObject({
+          Bucket: s3url.Bucket,
+          Key: s3url.Key,
+          VersionId: version.VersionId
+        }, function(err, data) {
+          if (err) return next(err);
+          next(null, {
+            date: new Date(version.LastModified),
+            data: Dyno.deserialize(data.Body.toString())
+          });
+        });
+      });
+    });
+
+    data.DeleteMarkers.forEach(function(del) {
+      q.defer(function(next) {
+        next(null, {
+          date: new Date(del.LastModified),
+          data: 'Record was deleted'
+        });
+      });
+    });
+
+    if (data.IsTruncated && data.NextVersionIdMarker)
+      return listVersions(data.NextVersionIdMarker);
+  });
+})();

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "incremental-backfill": "bin/incremental-backfill.js",
     "incremental-snapshot": "bin/incremental-snapshot.js",
     "incremental-backup-record": "bin/incremental-backup-record.js",
+    "incremental-record-history": "bin/incremental-record-history.js",
     "incremental-diff-record": "bin/incremental-diff-record.js"
   },
   "repository": {


### PR DESCRIPTION
- sorts attribute names in dynamodb record keys before making the md5 hash used to look up the object in the incremental backup
- adds an `incremental-record-history` CLI tool that prints versions of a record that exist in the incremental backup.