### PR TITLE
Configurable s3 region

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,13 +144,17 @@ function incrementalBackup(event, callback) {
         return allRecords;
     }, {});
 
-    var s3 = new AWS.S3({
+    var params = {
         maxRetries: 1000,
         httpOptions: {
             timeout: 1000,
             agent: streambot.agent
         }
-    });
+    };
+
+    if (process.env.BackupRegion) params.region = process.env.BackupRegion;
+
+    var s3 = new AWS.S3(params);
 
     printRemaining(events, true);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -133,6 +133,22 @@ test('[agent] return agent to normal', function(assert) {
     assert.end();
 });
 
+test('[incremental backup] configurable region', function(assert) {
+    process.env.BackupRegion = 'fake';
+    assert.plan(2);
+
+    var S3 = AWS.S3;
+    AWS.S3 = function(config) {
+        assert.equal(config.region, 'fake', 'configured region on S3 client');
+    };
+
+    backup({ Records: [] }, function(err) {
+        assert.ifError(err, 'backup success');
+        AWS.S3 = S3;
+        delete process.env.BackupRegion;
+    });
+});
+
 test('[incremental backup] insert', function(assert) {
     process.env.BackupPrefix = 'dynamodb-replicator/test/' + crypto.randomBytes(4).toString('hex');
 


### PR DESCRIPTION
Because when you reach across regions you often need to specify the region your bucket is in.