### PR TITLE
incremental-record-history handles archived versions

### DIFF
--- a/bin/incremental-record-history.js
+++ b/bin/incremental-record-history.js
@@ -101,7 +101,7 @@ q.awaitAll(function(err, results) {
                 }, function(err, data) {
                     if (err && err.name === 'InvalidObjectState') return next(null, {
                         date: new Date(version.LastModified),
-                        data: 'Version archived'
+                        data: 'Version archived: ' + version.VersionId
                     });
                     if (err) return next(err);
                     next(null, {

--- a/bin/incremental-record-history.js
+++ b/bin/incremental-record-history.js
@@ -99,6 +99,10 @@ q.awaitAll(function(err, results) {
                     Key: s3url.Key,
                     VersionId: version.VersionId
                 }, function(err, data) {
+                    if (err && err.name === 'InvalidObjectState') return next(null, {
+                        date: new Date(version.LastModified),
+                        data: 'Version archived'
+                    });
                     if (err) return next(err);
                     next(null, {
                         date: new Date(version.LastModified),


### PR DESCRIPTION
If a version of a record has been archived to glacier-class storage, `incremental-record-history` will not fail, instead providing you with a message like:

```
Modified: 2015-07-31T09:27:49.000Z
----------------------------------
Version archived: 4NgxU1Ib.pGqF8AVnPzNfZTHt0U3cGYV
```

You can then use the provided version id to run a [`restore-object` s3 api call](http://docs.aws.amazon.com/cli/latest/reference/s3api/restore-object.html) to retrieve the version should you need the details.

cc @mick