### PR TITLE
Bugfix for backfill/repair with lots to do

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -35,10 +35,9 @@ module.exports = function(config, done) {
         aggregation.records = [];
 
         aggregation._transform = function(record, enc, callback) {
-            if (aggregation.records.length < 25) {
-                aggregation.records.push(record);
-                return callback();
-            }
+            aggregation.records.push(record);
+
+            if (aggregation.records.length < 25) return callback();
 
             aggregation.push(aggregation.records);
             aggregation.records = [];
@@ -203,7 +202,7 @@ module.exports = function(config, done) {
                     writer.pending = false;
                     if (err) return callback(err);
 
-                    if (Object.keys(data.UnprocessedKeys).length)
+                    if (data.UnprocessedKeys && Object.keys(data.UnprocessedKeys).length)
                         return write({ RequestItems: data.UnprocessedKeys });
 
                     writer.params.RequestItems[replica.tableName] = [];

--- a/test/diff.test.js
+++ b/test/diff.test.js
@@ -189,6 +189,33 @@ primary.empty();
 replica.empty();
 primary.load(records);
 
+test('diff: repair/backfill large number of discrepancies', function(assert) {
+    config.repair = true;
+    config.backfill = true;
+    config.log.messages = [];
+
+    diff(config, function(err, discrepancies) {
+        assert.ifError(err, 'diff tables');
+        if (err) return assert.end();
+        assert.equal(discrepancies, 1000, '1000 records backfilled');
+
+        config.repair = false;
+        config.backfill = false;
+        config.log.messages = [];
+        diff(config, function(err, discrepancies) {
+            assert.ifError(err, 'diff tables');
+            if (err) return assert.end();
+
+            assert.equal(discrepancies, 0, '0 discrepancies post-backfill');
+            assert.end();
+        });
+    });
+});
+
+primary.empty();
+replica.empty();
+primary.load(records);
+
 test('diff: parallel', function(assert) {
     config.repair = false;
     config.backfill = false;


### PR DESCRIPTION
There was a gap in the tests that allowed a bug to slip through the cracks which came up when there were large numbers of features that needed to be backfilled or repaired in the replica.

Thanks for pointing this out @louism517!

Fixes #57 