### PR TITLE
Increase maxSockets on snapshot

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/mapbox/dynamodb-replicator",
   "dependencies": {
+    "agentkeepalive": "^2.0.3",
     "aws-sdk": "^2.2.17",
     "dyno": "^1.0.0",
     "fastlog": "^1.0.0",

--- a/s3-snapshot.js
+++ b/s3-snapshot.js
@@ -1,8 +1,8 @@
 var AWS = require('aws-sdk');
-var streambot = require('streambot');
 var s3scan = require('s3scan');
 var zlib = require('zlib');
 var stream = require('stream');
+var AgentKeepAlive = require('agentkeepalive');
 
 module.exports = function(config, done) {
     var log = config.log || console.log;
@@ -14,7 +14,14 @@ module.exports = function(config, done) {
         return done(new Error('Must provide destination bucket and key where the snapshot will be put'));
 
     var s3Options = {
-        httpOptions: { agent: streambot.agent }
+        httpOptions: {
+            timeout: 1000,
+            agent: new AgentKeepAlive.HttpsAgent({
+                keepAlive: true,
+                maxSockets: 256,
+                keepAliveTimeout: 60000
+            })
+        }
     };
     if (config.maxRetries) s3Options.maxRetries = config.maxRetries;
     if (config.logger) s3Options.logger = config.logger;


### PR DESCRIPTION
Snapshot script brings its own agent, sets maxSockets higher than streambot does by default.