### PR TITLE
s3scan@0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "fastlog": "^1.0.0",
     "minimist": "^1.1.0",
     "queue-async": "1.0.7",
-    "s3scan": "https://github.com/mapbox/s3scan/tarball/preemie",
+    "s3scan": "^0.1.3",
     "s3urls": "^1.3.0",
     "split": "^0.3.3",
     "streambot": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "fastlog": "^1.0.0",
     "minimist": "^1.1.0",
     "queue-async": "1.0.7",
-    "s3scan": "^0.1.2",
+    "s3scan": "https://github.com/mapbox/s3scan/tarball/preemie",
     "s3urls": "^1.3.0",
     "split": "^0.3.3",
     "streambot": "^3.3.0",


### PR DESCRIPTION
Circumvents a bug in aws-sdk that could lead to backups not containing all the items that they ought to contain.