### PR TITLE
Optionally allow use of different credentials for writing to replica

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ module.exports.streambotBackup = streambot(incrementalBackup);
 
 function replicate(event, callback) {
     var replicaConfig = {
+        accessKeyId: process.env.ReplicaAccessKeyId || undefined,
+        secretAccessKey: process.env.ReplicaSecretAccessKey || undefined,
         table: process.env.ReplicaTable,
         region: process.env.ReplicaRegion,
         maxRetries: 1000,


### PR DESCRIPTION
Adds the ability to optionally use a different set of credentials for writing to the DB replica. Useful for replication across AWS accounts.