### PR TITLE
Fix Authentication Mechanism error in eu-central-1

### DIFF
--- a/backup.js
+++ b/backup.js
@@ -5,7 +5,9 @@ var zlib = require('zlib');
 
 module.exports = function(config, done) {
     var primary = Dyno(config);
-    var s3 = new AWS.S3();
+    var s3 = new AWS.S3({
+        signatureVersion: 'v4'
+    });
 
     var log = config.log || console.log;
     var scanOpts = config.hasOwnProperty('segment') && config.segments ?


### PR DESCRIPTION
There was an authentication error when trying to run a backup using the `eu-central-1` region. According to [Stackoverflow](http://stackoverflow.com/a/26538266/518801) the default mechanism (`v2`) was never available in `eu-central-1`. Setting the authentication mechanism fixed the issue for me.