### PR TITLE
Increase socket timeout on replication

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,15 +28,10 @@ function replicate(event, context, callback) {
         region: process.env.ReplicaRegion,
         maxRetries: 1000,
         httpOptions: {
-            timeout: 750,
+            timeout: 2000,
             agent: module.exports.agent
         }
     };
-
-    if (context.invokeId === 'cadf5396-3939-4085-a4ca-d5d2280a2d6d') {
-        console.log('SKIPPING STALLED INVOCATION cadf5396-3939-4085-a4ca-d5d2280a2d6d');
-        return callback();
-    }
 
     if (process.env.ReplicaEndpoint) replicaConfig.endpoint = process.env.ReplicaEndpoint;
     var replica = new Dyno(replicaConfig);

--- a/index.js
+++ b/index.js
@@ -32,6 +32,12 @@ function replicate(event, context, callback) {
             agent: module.exports.agent
         }
     };
+
+    if (context.invokeId === 'cadf5396-3939-4085-a4ca-d5d2280a2d6d') {
+        console.log('SKIPPING STALLED INVOCATION cadf5396-3939-4085-a4ca-d5d2280a2d6d');
+        return callback();
+    }
+
     if (process.env.ReplicaEndpoint) replicaConfig.endpoint = process.env.ReplicaEndpoint;
     var replica = new Dyno(replicaConfig);
 
@@ -134,7 +140,7 @@ function incrementalBackup(event, context, callback) {
     if (process.env.BackupRegion) params.region = process.env.BackupRegion;
 
     var s3 = new AWS.S3(params);
-    
+
     var filterer;
     if (process.env.TurnoverRole && process.env.TurnoverAt) {
         // Filterer function should return true if the record SHOULD be processed


### PR DESCRIPTION
When large items are being written to the replica table, we occasionally see BatchWrite requests that consistently timeout.

Our hunch is that communication over the socket goes quiet for >750ms while the DynamoDB on the receiving end is busy writing all the data to the replica table. If that silence lasts too long, then the aws-sdk on the sending end times out, and tries again.

This PR increases that timeout interval from 750ms --> 2000ms.

cc @arunasank @mcwhittemore 