### PR TITLE
allow tests to be run against any S3 bucket owned by any account

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint *.js bin/*.js test/*.js",
-    "test": "tape test/*.test.js"
+    "test": "tape -r ./test/env.js test/*.test.js"
   },
   "bin": {
     "diff-tables": "bin/diff-tables.js",

--- a/test/backup.test.js
+++ b/test/backup.test.js
@@ -27,7 +27,7 @@ dynamodb.start();
 dynamodb.test('backup: one segment', primaryItems, function(assert) {
     var config = {
         backup: {
-            bucket: 'mapbox',
+            bucket: process.env.BackupBucket,
             prefix: 'dynamodb-replicator/test',
             jobid: crypto.randomBytes(4).toString('hex')
         },
@@ -46,7 +46,7 @@ dynamodb.test('backup: one segment', primaryItems, function(assert) {
         assert.equal(details.size, 98, 'reported 98 bytes');
 
         s3.getObject({
-            Bucket: 'mapbox',
+            Bucket: process.env.BackupBucket,
             Key: [config.backup.prefix, config.backup.jobid, '0'].join('/')
         }, function(err, data) {
             assert.ifError(err, 'retrieved backup from S3');
@@ -72,7 +72,7 @@ dynamodb.test('backup: one segment', primaryItems, function(assert) {
 dynamodb.test('backup: parallel', records, function(assert) {
     var config = {
         backup: {
-            bucket: 'mapbox',
+            bucket: process.env.BackupBucket,
             prefix: 'dynamodb-replicator/test',
             jobid: crypto.randomBytes(4).toString('hex')
         },
@@ -92,8 +92,8 @@ dynamodb.test('backup: parallel', records, function(assert) {
     queue(1)
         .defer(backup, firstConfig)
         .defer(backup, secondConfig)
-        .defer(s3.getObject.bind(s3), { Bucket: 'mapbox', Key: firstKey })
-        .defer(s3.getObject.bind(s3), { Bucket: 'mapbox', Key: secondKey })
+        .defer(s3.getObject.bind(s3), { Bucket: process.env.BackupBucket, Key: firstKey })
+        .defer(s3.getObject.bind(s3), { Bucket: process.env.BackupBucket, Key: secondKey })
         .awaitAll(function(err, results) {
             assert.ifError(err, 'all requests completed');
             if (err) return assert.end();

--- a/test/env.js
+++ b/test/env.js
@@ -1,0 +1,4 @@
+'use strict';
+
+// use a different S3 bucket by defining BackupBucket in the ENV
+process.env.BackupBucket = process.env.BackupBucket || 'mapbox';

--- a/test/incremental.test.js
+++ b/test/incremental.test.js
@@ -14,7 +14,7 @@ var fs = require('fs');
 var backfill = require('../s3-backfill');
 var snapshot = require('../s3-snapshot');
 
-var bucket = 'mapbox';
+var bucket = process.env.BackupBucket;
 var prefix = 'dynamodb-replicator/test/' + crypto.randomBytes(4).toString('hex');
 var records = require('./fixtures/records')(50);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -29,7 +29,6 @@ process.env.ReplicaRegion = 'mock';
 process.env.ReplicaEndpoint = 'http://localhost:4567';
 process.env.AWS_ACCESS_KEY_ID = 'mock';
 process.env.AWS_SECRET_ACCESS_KEY = 'mock';
-process.env.BackupBucket = 'mapbox';
 
 var httpsAgent;
 test('[agent] use http agent for replication tests', function(assert) {

--- a/test/live-test.backup-table.js
+++ b/test/live-test.backup-table.js
@@ -22,7 +22,7 @@ dynamodb.test('backup-table shell script', primaryItems, function(assert) {
     var cmd = [
         path.resolve(__dirname, '..', 'bin', 'backup-table.js'),
         'us-east-1/' + dynamodb.tableName,
-        's3://mapbox/dynamodb-replicator/test',
+        's3://' + process.env.BackupBucket + '/dynamodb-replicator/test',
         '--jobid', jobid,
         '--segment 0',
         '--segments 1',
@@ -40,7 +40,7 @@ dynamodb.test('backup-table shell script', primaryItems, function(assert) {
             queue()
                 .defer(function(next) {
                     s3.getObject({
-                        Bucket: 'mapbox',
+                        Bucket: process.env.BackupBucket,
                         Key: 'dynamodb-replicator/test/' + jobid + '/0'
                     }, function(err, data) {
                         assert.ifError(err, 'S3 getObject success');


### PR DESCRIPTION
... so that it doesn't need to be named 'mapbox'. The bucket named by the ENV variable BackupBucket will be used. BackupBucket is set to 'mapbox' in test/env.js which is loaded when 'npm test' is run.