### PR TITLE
encrypt all the bits

### DIFF
--- a/backup.js
+++ b/backup.js
@@ -40,6 +40,8 @@ module.exports = function(config, done) {
     log('[segment %s] Starting backup job %s of %s', index, config.backup.jobid, config.region + '/' + config.table);
 
     s3.upload({
+        ServerSideEncryption: process.env.ServerSideEncryption || 'AES256',
+        SSEKMSKeyId: process.env.SSEKMSKeyId,
         Bucket: config.backup.bucket,
         Key: key,
         Body: data

--- a/index.js
+++ b/index.js
@@ -193,7 +193,11 @@ function incrementalBackup(event, context, callback) {
                 };
 
                 var req = change.eventName === 'REMOVE' ? 'deleteObject' : 'putObject';
-                if (req === 'putObject') params.Body = JSON.stringify(change.dynamodb.NewImage);
+                if (req === 'putObject') {
+                    params.Body = JSON.stringify(change.dynamodb.NewImage);
+                    params.ServerSideEncryption = process.env.ServerSideEncryption || 'AES256';
+                    params.SSEKMSKeyId = process.env.SSEKMSKeyId;
+                }
 
                 s3[req](params, function(err) {
                     if (err) console.log(

--- a/s3-backfill.js
+++ b/s3-backfill.js
@@ -58,6 +58,8 @@ function backfill(config, done) {
                 .digest('hex');
 
             var params = {
+                ServerSideEncryption: process.env.ServerSideEncryption || 'AES256',
+                SSEKMSKeyId: process.env.SSEKMSKeyId,
                 Bucket: config.backup.bucket,
                 Key: [config.backup.prefix, config.table, id].join('/'),
                 Body: Dyno.serialize(record)

--- a/s3-snapshot.js
+++ b/s3-snapshot.js
@@ -45,6 +45,8 @@ module.exports = function(config, done) {
     };
 
     var upload = s3.upload({
+        ServerSideEncryption: process.env.ServerSideEncryption || 'AES256',
+        SSEKMSKeyId: process.env.SSEKMSKeyId,
         Bucket: config.destination.bucket,
         Key: config.destination.key,
         Body: gzip


### PR DESCRIPTION
enable S3 ServerSideEncryption for all writes. S3 doesn't charge any extra for using encryption and there's no reason not to.  AES256 using the S3 managed keys are used by default but can be changed to use KMS keys be setting the ENV variables ServerSideEncryption='aws:kms' and SSEKMSKeyId=kms-key-id