### PR TITLE
Order keys for s3

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,8 +181,13 @@ function incrementalBackup(event, context, callback) {
 
         changes.forEach(function(change) {
             q.defer(function(next) {
+                var unordered = change.dynamodb.Keys;
+                var ordered = Object.keys(unordered).sort().reduce(function (ordered, key) {
+                    ordered[key] = unordered[key];
+                    return ordered
+                }, {});
                 var id = crypto.createHash('md5')
-                    .update(JSON.stringify(change.dynamodb.Keys))
+                    .update(JSON.stringify(ordered))
                     .digest('hex');
 
                 var table = change.eventSourceARN.split('/')[1];

--- a/s3-backfill.js
+++ b/s3-backfill.js
@@ -33,7 +33,7 @@ function backfill(config, done) {
 
         var keys = data.Table.KeySchema.map(function(schema) {
             return schema.AttributeName;
-        });
+        }).sort(); // ensure keys are sorted by name and not declaration order which DDB requires to be HASH first
 
         var count = 0;
         var starttime = Date.now();

--- a/test/fixtures/events/adjust-many.json
+++ b/test/fixtures/events/adjust-many.json
@@ -6,7 +6,10 @@
             "eventSource":"aws:dynamodb",
             "dynamodb": {
                 "NewImage":{
-                    "range": {
+                    "data": {
+                        "S": "data-1"
+                    },
+                    "arange": {
                         "N": "1"
                     },
                     "id": {
@@ -19,6 +22,9 @@
                 "Keys":{
                     "id": {
                         "S": "record-1"
+                    },
+                    "arange": {
+                        "N": "1"
                     }
                 }
             },
@@ -32,8 +38,11 @@
             "eventSource":"aws:dynamodb",
             "dynamodb": {
                 "NewImage":{
-                    "range": {
-                        "N": "11"
+                    "data": {
+                        "S": "data-2"
+                    },
+                    "arange": {
+                        "N": "1"
                     },
                     "id": {
                         "S": "record-1"
@@ -43,7 +52,10 @@
                 "StreamViewType":"NEW_AND_OLD_IMAGES",
                 "SequenceNumber":"222",
                 "OldImage":{
-                    "range": {
+                    "data": {
+                        "S": "data-1"
+                    },
+                    "arange": {
                         "N": "1"
                     },
                     "id": {
@@ -53,6 +65,9 @@
                 "Keys":{
                     "id": {
                         "S": "record-1"
+                    },
+                    "arange": {
+                        "N": "1"
                     }
                 }
             },
@@ -66,7 +81,10 @@
             "eventSource":"aws:dynamodb",
             "dynamodb": {
                 "NewImage":{
-                    "range": {
+                    "data": {
+                        "S": "data-1"
+                    },
+                    "arange": {
                         "N": "1"
                     },
                     "id": {
@@ -79,6 +97,9 @@
                 "Keys":{
                     "id": {
                         "S": "record-3"
+                    },
+                    "arange": {
+                        "N": "1"
                     }
                 }
             },
@@ -92,7 +113,10 @@
             "eventSource":"aws:dynamodb",
             "dynamodb": {
                 "NewImage":{
-                    "range": {
+                    "data": {
+                        "S": "data-1"
+                    },
+                    "arange": {
                         "N": "1"
                     },
                     "id": {
@@ -105,6 +129,9 @@
                 "Keys":{
                     "id": {
                         "S": "record-2"
+                    },
+                    "arange": {
+                        "N": "1"
                     }
                 }
             },
@@ -118,8 +145,11 @@
             "eventSource":"aws:dynamodb",
             "dynamodb": {
                 "NewImage":{
-                    "range": {
-                        "N": "22"
+                    "data": {
+                        "S": "data-2"
+                    },
+                    "arange": {
+                        "N": "1"
                     },
                     "id": {
                         "S": "record-2"
@@ -129,7 +159,10 @@
                 "StreamViewType":"NEW_AND_OLD_IMAGES",
                 "SequenceNumber":"222",
                 "OldImage":{
-                    "range": {
+                    "data": {
+                        "S": "data-1"
+                    },
+                    "arange": {
                         "N": "1"
                     },
                     "id": {
@@ -139,6 +172,9 @@
                 "Keys":{
                     "id": {
                         "S": "record-2"
+                    },
+                    "arange": {
+                        "N": "1"
                     }
                 }
             },
@@ -155,8 +191,11 @@
                 "StreamViewType":"NEW_AND_OLD_IMAGES",
                 "SequenceNumber":"333",
                 "OldImage":{
-                    "range": {
-                        "N": "11"
+                    "data": {
+                        "S": "data-2"
+                    },
+                    "arange": {
+                        "N": "1"
                     },
                     "id": {
                         "S": "record-1"
@@ -165,6 +204,9 @@
                 "Keys":{
                     "id": {
                         "S": "record-1"
+                    },
+                    "arange": {
+                        "N": "1"
                     }
                 }
             },
@@ -178,8 +220,11 @@
             "eventSource":"aws:dynamodb",
             "dynamodb": {
                 "NewImage":{
-                    "range": {
-                        "N": "33"
+                    "data": {
+                        "S": "data-2"
+                    },
+                    "arange": {
+                        "N": "1"
                     },
                     "id": {
                         "S": "record-3"
@@ -189,7 +234,10 @@
                 "StreamViewType":"NEW_AND_OLD_IMAGES",
                 "SequenceNumber":"222",
                 "OldImage":{
-                    "range": {
+                    "data": {
+                        "S": "data-1"
+                    },
+                    "arange": {
                         "N": "1"
                     },
                     "id": {
@@ -199,6 +247,9 @@
                 "Keys":{
                     "id": {
                         "S": "record-3"
+                    },
+                    "arange": {
+                        "N": "1"
                     }
                 }
             },

--- a/test/fixtures/events/insert-buffer.json
+++ b/test/fixtures/events/insert-buffer.json
@@ -6,7 +6,7 @@
             "eventSource":"aws:dynamodb",
             "dynamodb": {
                 "NewImage":{
-                    "range": {
+                    "arange": {
                         "N": "1"
                     },
                     "id": {
@@ -44,6 +44,9 @@
                 "Keys":{
                     "id": {
                         "S": "record-1"
+                    },
+                    "arange": {
+                        "N": "1"
                     }
                 }
             },

--- a/test/fixtures/events/insert-modify-delete.json
+++ b/test/fixtures/events/insert-modify-delete.json
@@ -6,7 +6,10 @@
             "eventSource":"aws:dynamodb",
             "dynamodb": {
                 "NewImage":{
-                    "range": {
+                    "data": {
+                        "S": "data-1"
+                    },
+                    "arange": {
                         "N": "1"
                     },
                     "id": {
@@ -19,6 +22,9 @@
                 "Keys":{
                     "id": {
                         "S": "record-1"
+                    },
+                    "arange": {
+                        "N": "1"
                     }
                 }
             },
@@ -32,8 +38,11 @@
             "eventSource":"aws:dynamodb",
             "dynamodb": {
                 "NewImage":{
-                    "range": {
-                        "N": "2"
+                    "data": {
+                        "S": "data-2"
+                    },
+                    "arange": {
+                        "N": "1"
                     },
                     "id": {
                         "S": "record-1"
@@ -43,7 +52,10 @@
                 "StreamViewType":"NEW_AND_OLD_IMAGES",
                 "SequenceNumber":"222",
                 "OldImage":{
-                    "range": {
+                    "data": {
+                        "S": "data-1"
+                    },
+                    "arange": {
                         "N": "1"
                     },
                     "id": {
@@ -53,6 +65,9 @@
                 "Keys":{
                     "id": {
                         "S": "record-1"
+                    },
+                    "arange": {
+                        "N": "1"
                     }
                 }
             },
@@ -69,8 +84,11 @@
                 "StreamViewType":"NEW_AND_OLD_IMAGES",
                 "SequenceNumber":"333",
                 "OldImage":{
-                    "range": {
-                        "N": "2"
+                    "data": {
+                        "S": "data-2"
+                    },
+                    "arange": {
+                        "N": "1"
                     },
                     "id": {
                         "S": "record-1"
@@ -79,6 +97,9 @@
                 "Keys":{
                     "id": {
                         "S": "record-1"
+                    },
+                    "arange": {
+                        "N": "1"
                     }
                 }
             },

--- a/test/fixtures/events/insert-modify.json
+++ b/test/fixtures/events/insert-modify.json
@@ -6,7 +6,10 @@
             "eventSource":"aws:dynamodb",
             "dynamodb": {
                 "NewImage":{
-                    "range": {
+                    "data": {
+                        "S": "data-1"
+                    },
+                    "arange": {
                         "N": "1"
                     },
                     "id": {
@@ -19,6 +22,9 @@
                 "Keys":{
                     "id": {
                         "S": "record-1"
+                    },
+                    "arange": {
+                        "N": "1"
                     }
                 }
             },
@@ -32,8 +38,11 @@
             "eventSource":"aws:dynamodb",
             "dynamodb": {
                 "NewImage":{
-                    "range": {
-                        "N": "2"
+                    "data": {
+                        "S": "data-2"
+                    },
+                    "arange": {
+                        "N": "1"
                     },
                     "id": {
                         "S": "record-1"
@@ -43,7 +52,10 @@
                 "StreamViewType":"NEW_AND_OLD_IMAGES",
                 "SequenceNumber":"222",
                 "OldImage":{
-                    "range": {
+                    "data": {
+                        "S": "data-1"
+                    },
+                    "arange": {
                         "N": "1"
                     },
                     "id": {
@@ -53,6 +65,9 @@
                 "Keys":{
                     "id": {
                         "S": "record-1"
+                    },
+                    "arange": {
+                        "N": "1"
                     }
                 }
             },

--- a/test/fixtures/events/insert.json
+++ b/test/fixtures/events/insert.json
@@ -6,7 +6,7 @@
             "eventSource":"aws:dynamodb",
             "dynamodb": {
                 "NewImage":{
-                    "range": {
+                    "arange": {
                         "N": "1"
                     },
                     "id": {
@@ -19,6 +19,9 @@
                 "Keys":{
                     "id": {
                         "S": "record-1"
+                    },
+                    "arange": {
+                        "N": "1"
                     }
                 }
             },

--- a/test/fixtures/records.js
+++ b/test/fixtures/records.js
@@ -5,6 +5,7 @@ module.exports = function(num) {
     return _.range(0, num).map(function() {
         return {
             id: crypto.randomBytes(16).toString('hex'),
+            arange: Math.random(),
             data: crypto.randomBytes(256).toString('base64')
         };
     });

--- a/test/fixtures/table.js
+++ b/test/fixtures/table.js
@@ -1,9 +1,11 @@
 module.exports = {
     AttributeDefinitions: [
-        {AttributeName: 'id', AttributeType: 'S'}
+        {AttributeName: 'id', AttributeType: 'S'},
+        {AttributeName: 'arange', AttributeType: 'N'}
     ],
     KeySchema: [
-        {AttributeName: 'id', KeyType: 'HASH'}
+        {AttributeName: 'id', KeyType: 'HASH'},
+        {AttributeName: 'arange', KeyType: 'RANGE'}
     ],
     ProvisionedThroughput: {
         ReadCapacityUnits: 1,

--- a/test/incremental.test.js
+++ b/test/incremental.test.js
@@ -53,7 +53,8 @@ dynamodb.test('[s3-backfill]', records, function(assert) {
 
         records.forEach(function(expected) {
             var key = crypto.createHash('md5')
-                .update(Dyno.serialize({ id: expected.id }))
+                // key names here must be in alphabetical order to match impl which is expected to sort them
+                .update(Dyno.serialize({ arange: expected.arange, id: expected.id }))
                 .digest('hex');
 
             key = [prefix, dynamodb.tableName, key].join('/');


### PR DESCRIPTION
As reported in #90 there is a bug with key ordering when computing S3 keys. The bug reporter submitted a PR #91 which was never accepted. Maybe the use of ES6 features or lack of tests to demonstrate the bug was at issue.

This PR updates the existing tests to use a range key so that the issue is obvious and an ES5 compatible fix to the incremental and backfill functions that are affected.
