### PR TITLE
Fix incremental-snapshot

### DIFF
--- a/s3-snapshot.js
+++ b/s3-snapshot.js
@@ -40,7 +40,7 @@ module.exports = function(config, done) {
     var stringify = new stream.Transform();
     stringify._writableState.objectMode = true;
     stringify._transform = function(data, enc, callback) {
-        if (!data) return callback();
+        if (!data || !data.Body) return callback();
         callback(null, data.Body.toString() + '\n');
     };
 


### PR DESCRIPTION
`incremental-snapshot` didn't work for me without this change. Instead
it would throw the following exception:

    TypeError: Cannot read property 'toString' of undefined
        at Transform.stringify._transform
        (/some/path/dynamodb-replicator/s3-snapshot.js:43:33)
        at Transform._read (_stream_transform.js:167:10)
        at Transform._write (_stream_transform.js:155:12)
        at doWrite (_stream_writable.js:329:12)
        at writeOrBuffer (_stream_writable.js:315:5)
        at Transform.Writable.write (_stream_writable.js:241:11)
        at Transform.ondata (_stream_readable.js:557:20)
        at emitOne (events.js:96:13)
        at Transform.emit (events.js:191:7)
        at readableAddChunk (_stream_readable.js:178:18)