### PR TITLE
Add trailing line breaks to incremental backups

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,7 +193,7 @@ function incrementalBackup(event, context, callback) {
                 };
 
                 var req = change.eventName === 'REMOVE' ? 'deleteObject' : 'putObject';
-                if (req === 'putObject') params.Body = JSON.stringify(change.dynamodb.NewImage);
+                if (req === 'putObject') params.Body = JSON.stringify(change.dynamodb.NewImage) + '\n';
 
                 s3[req](params, function(err) {
                     if (err) console.log(

--- a/s3-snapshot.js
+++ b/s3-snapshot.js
@@ -41,7 +41,9 @@ module.exports = function(config, done) {
     stringify._writableState.objectMode = true;
     stringify._transform = function(data, enc, callback) {
         if (!data) return callback();
-        callback(null, data.Body.toString() + '\n');
+        var body = data.Body.toString();
+        if (!body.endsWith('\n')) body += '\n';
+        callback(null, body);
     };
 
     var upload = s3.upload({


### PR DESCRIPTION
Up to now incremental backups didn't contain a trailing line break at
the end of the file. When aggregating incremental records into a
snapshot `dynamodb-replicator` would add them.
This commit changes that to include trailing line breaks in the
incremental backups and only add them during snapshotting when they're
not present.
The motivation for this change is that it makes it significantly easier
to process incremental backups with tools such as the `awscli` if they
already contain the trailing line break.