### PR TITLE
use sha256 instead of md5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-dist: jammy
-language: node_js
-node_js:
-  - 18
-sudo: false
-script:
-  - npm test
-  - node test/live-test.backup-table.js

--- a/bin/incremental-diff-record.js
+++ b/bin/incremental-diff-record.js
@@ -72,7 +72,7 @@ catch (err) { key = JSON.parse(key); }
 s3url.Key = [
     s3url.Key,
     table,
-    crypto.createHash('md5')
+    crypto.createHash('sha256')
         .update(Dyno.serialize(key))
         .digest('hex')
 ].join('/');

--- a/bin/incremental-record-history.js
+++ b/bin/incremental-record-history.js
@@ -70,7 +70,7 @@ catch (err) { key = JSON.parse(key); }
 s3url.Key = [
     s3url.Key,
     table,
-    crypto.createHash('md5')
+    crypto.createHash('sha256')
         .update(Dyno.serialize(key))
         .digest('hex')
 ].join('/');

--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ function incrementalBackup(event, context, callback) {
 
         changes.forEach(function(change) {
             q.defer(function(next) {
-                var id = crypto.createHash('md5')
+                var id = crypto.createHash('sha256')
                     .update(JSON.stringify(change.dynamodb.Keys))
                     .digest('hex');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dynamodb-replicator",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/s3-backfill.js
+++ b/s3-backfill.js
@@ -53,7 +53,7 @@ function backfill(config, done) {
                 return key;
             }, {});
 
-            var id = crypto.createHash('md5')
+            var id = crypto.createHash('sha256')
                 .update(Dyno.serialize(key))
                 .digest('hex');
 

--- a/test/backup.test.js
+++ b/test/backup.test.js
@@ -43,7 +43,7 @@ dynamodb.test('backup: one segment', primaryItems, function(assert) {
         if (err) return assert.end();
 
         assert.equal(details.count, 3, 'reported 3 records');
-        assert.equal(details.size, 98, 'reported 98 bytes');
+        assert.equal(details.size, 101, 'reported 101 bytes');
 
         s3.getObject({
             Bucket: 'mapbox',

--- a/test/incremental.test.js
+++ b/test/incremental.test.js
@@ -52,7 +52,7 @@ dynamodb.test('[s3-backfill]', records, function(assert) {
         var q = queue(20);
 
         records.forEach(function(expected) {
-            var key = crypto.createHash('md5')
+            var key = crypto.createHash('sha256')
                 .update(Dyno.serialize({ id: expected.id }))
                 .digest('hex');
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -155,7 +155,7 @@ test('[incremental backup] insert', function(assert) {
 
     var event = require(path.join(events, 'insert.json'));
     var table = event.Records[0].eventSourceARN.split('/')[1];
-    var id = crypto.createHash('md5')
+    var id = crypto.createHash('sha256')
         .update(JSON.stringify(event.Records[0].dynamodb.Keys))
         .digest('hex');
 
@@ -182,7 +182,7 @@ test('[incremental backup] insert & modify', function(assert) {
 
     var event = require(path.join(events, 'insert-modify.json'));
     var table = event.Records[0].eventSourceARN.split('/')[1];
-    var id = crypto.createHash('md5')
+    var id = crypto.createHash('sha256')
         .update(JSON.stringify(event.Records[0].dynamodb.Keys))
         .digest('hex');
 
@@ -209,7 +209,7 @@ test('[incremental backup] insert, modify & delete', function(assert) {
 
     var event = require(path.join(events, 'insert-modify-delete.json'));
     var table = event.Records[0].eventSourceARN.split('/')[1];
-    var id = crypto.createHash('md5')
+    var id = crypto.createHash('sha256')
         .update(JSON.stringify(event.Records[0].dynamodb.Keys))
         .digest('hex');
 
@@ -244,7 +244,7 @@ test('[incremental backup] adjust many', function(assert) {
         expected.forEach(function(record) {
             q.defer(function(next) {
                 var key = { id: record.id };
-                var id = crypto.createHash('md5')
+                var id = crypto.createHash('sha256')
                     .update(JSON.stringify(key))
                     .digest('hex');
 
@@ -264,7 +264,7 @@ test('[incremental backup] adjust many', function(assert) {
         });
 
         q.defer(function(next) {
-            var id = crypto.createHash('md5')
+            var id = crypto.createHash('sha256')
                 .update(JSON.stringify({ id: { S: 'record-1' } }))
                 .digest('hex');
 

--- a/test/live-test.backup-table.js
+++ b/test/live-test.backup-table.js
@@ -69,7 +69,7 @@ dynamodb.test('backup-table shell script', primaryItems, function(assert) {
                             return next();
                         }
                         assert.equal(data.Datapoints.length, 1, 'BackupSize put to CW');
-                        assert.equal(data.Datapoints[0].Sum, 99, 'Correct BackupSize value on CW');
+                        assert.equal(data.Datapoints[0].Sum, 101, 'Correct BackupSize value on CW');
                         next();
                     });
                 })


### PR DESCRIPTION
There's a [CWE](https://cwe.mitre.org/data/definitions/328.html) for the use of md5 in createHash, this changes it to sha256 as recommended. Also removes the Travis config file as that's been deprecated. 

The incorrect sizes being asserted in the tests were failing on master already and are unrelated to this change - given how infrequently we touch this repo, I'm guessing it broke a while back and just didn't get fixed. Running the test script mentioned in the travis config is successful:
<img width="344" alt="image" src="https://github.com/user-attachments/assets/4e0191bf-5f36-4be5-a50e-cae653472521" />
