### PR TITLE
Updating aws sdk to v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# [11.0.1](https://github.com/mapbox/dynamodb-replicator/pull/116) July 21, 2025
+
+**Potential Breaking Change**: Upgrading all aws sdk v2
+usage to aws sdk v3. AWS sdk v2 EOL is September 2025, so
+this change is mandatory for standard upkeep.

--- a/backup.js
+++ b/backup.js
@@ -1,11 +1,12 @@
-var AWS = require('aws-sdk');
+var { S3Client } = require('@aws-sdk/client-s3');
+var { Upload } = require('@aws-sdk/lib-storage');
 var Dyno = require('@mapbox/dyno');
 var stream = require('stream');
 var zlib = require('zlib');
 
 module.exports = function(config, done) {
     var primary = Dyno(config);
-    var s3 = new AWS.S3();
+    var s3Client = new S3Client({ region: config.region });
 
     var log = config.log || console.log;
 
@@ -40,19 +41,29 @@ module.exports = function(config, done) {
 
     log('[segment %s] Starting backup job %s of %s', index, config.backup.jobid, config.region + '/' + config.table);
 
-    s3.upload({
-        Bucket: config.backup.bucket,
-        Key: key,
-        Body: data
-    }, function(err) {
-        if (err) return next(err);
-        log('[segment %s] Uploaded dynamo backup to s3://%s/%s', index, config.backup.bucket, key);
-        log('[segment %s] Wrote %s items to backup', index, count);
-        next();
-    }).on('httpUploadProgress', function(progress) {
-        log('[segment %s] Uploaded %s bytes', index, progress.loaded);
-        size = progress.total;
+    const upload = new Upload({
+        client: s3Client,
+        params: {
+            Bucket: config.backup.bucket,
+            Key: key,
+            Body: data
+        }
     });
+
+    upload.on('httpUploadProgress', function(progress) {
+        log('[segment %s] Uploaded %s bytes', index, progress.loaded);
+        size = progress.loaded;
+    });
+
+    upload.done()
+        .then(() => {
+            log('[segment %s] Uploaded dynamo backup to s3://%s/%s', index, config.backup.bucket, key);
+            log('[segment %s] Wrote %s items to backup', index, count);
+            next();
+        })
+        .catch(err => {
+            next(err);
+        });
 
     function next(err) {
         if (err) return done(err);

--- a/bin/backup-table.js
+++ b/bin/backup-table.js
@@ -5,7 +5,7 @@ var fastlog = require('../fastlog');
 var args = require('minimist')(process.argv.slice(2));
 var crypto = require('crypto');
 var s3urls = require('s3urls');
-var AWS = require('aws-sdk');
+var { CloudWatchClient, PutMetricDataCommand } = require('@aws-sdk/client-cloudwatch');
 
 function usage() {
     console.error('');
@@ -64,7 +64,7 @@ backup(config, function(err, details) {
     if (err) log.error(err);
 
     if (args.metric) {
-        var cw = new AWS.CloudWatch({ region: config.region });
+        var cwClient = new CloudWatchClient({ region: config.region });
         var params = {
             Namespace: args.metric,
             MetricData: []
@@ -107,8 +107,12 @@ backup(config, function(err, details) {
             });
         }
 
-        cw.putMetricData(params, function(err) {
-            if (err) log.error(err);
-        });
+        cwClient.send(new PutMetricDataCommand(params))
+            .then(() => {
+                // Success
+            })
+            .catch(err => {
+                log.error(err);
+            });
     }
 });

--- a/bin/incremental-diff-record.js
+++ b/bin/incremental-diff-record.js
@@ -4,8 +4,7 @@ var minimist = require('minimist');
 var s3urls = require('s3urls');
 var Dyno = require('@mapbox/dyno');
 var crypto = require('crypto');
-var AWS = require('aws-sdk');
-var s3 = new AWS.S3();
+var { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3');
 var assert = require('assert');
 
 var args = minimist(process.argv.slice(2));
@@ -33,6 +32,8 @@ if (!table) {
 
 var region = table.split('/')[0];
 table = table.split('/')[1];
+
+var s3Client = new S3Client({ region: region });
 
 var s3url = args._[1];
 
@@ -86,30 +87,51 @@ dyno.getItem({ Key: key }, function(err, data) {
     if (err) throw err;
     var dynamoRecord = data.Item;
 
-    s3.getObject(s3url, function(err, data) {
-        if (err && err.statusCode !== 404) throw err;
-        var s3data = err ? undefined : Dyno.deserialize(data.Body.toString());
+    s3Client.send(new GetObjectCommand(s3url))
+        .then(data => {
+            var s3data = Dyno.deserialize(data.Body.toString());
 
-        console.log('DynamoDB record');
-        console.log('--------------');
-        console.log(dynamoRecord);
-        console.log('');
+            console.log('DynamoDB record');
+            console.log('--------------');
+            console.log(dynamoRecord);
+            console.log('');
 
-        console.log('Incremental backup record (%s)', s3url.Key);
-        console.log('--------------');
-        console.log(s3data);
-        console.log('');
+            console.log('Incremental backup record (%s)', s3url.Key);
+            console.log('--------------');
+            console.log(s3data);
+            console.log('');
 
-        try {
-            assert.deepEqual(s3data, dynamoRecord);
-            console.log('----------------------------');
-            console.log('✔ The records are equivalent');
-            console.log('----------------------------');
-        }
-        catch (err) {
-            console.log('--------------------------------');
-            console.log('✘ The records are not equivalent');
-            console.log('--------------------------------');
-        }
-    });
+            try {
+                assert.deepEqual(s3data, dynamoRecord);
+                console.log('----------------------------');
+                console.log('✔ The records are equivalent');
+                console.log('----------------------------');
+            }
+            catch (err) {
+                console.log('--------------------------------');
+                console.log('✘ The records are not equivalent');
+                console.log('--------------------------------');
+            }
+        })
+        .catch(err => {
+            if (err.$metadata && err.$metadata.httpStatusCode === 404) {
+                var s3data = undefined;
+
+                console.log('DynamoDB record');
+                console.log('--------------');
+                console.log(dynamoRecord);
+                console.log('');
+
+                console.log('Incremental backup record (%s)', s3url.Key);
+                console.log('--------------');
+                console.log(s3data);
+                console.log('');
+
+                console.log('--------------------------------');
+                console.log('✘ The records are not equivalent');
+                console.log('--------------------------------');
+            } else {
+                throw err;
+            }
+        });
 });

--- a/bin/incremental-snapshot.js
+++ b/bin/incremental-snapshot.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-var AWS = require('aws-sdk');
+var { CloudWatchClient, PutMetricDataCommand } = require('@aws-sdk/client-cloudwatch');
 var args = require('minimist')(process.argv.slice(2));
 var s3urls = require('s3urls');
 var fastlog = require('../fastlog');
@@ -59,7 +59,7 @@ snapshot(config, function(err, details) {
         var namespace = args.metric.split('/')[1];
         var table = args.metric.split('/')[2];
 
-        var cw = new AWS.CloudWatch({ region: region });
+        var cwClient = new CloudWatchClient({ region: region });
 
         var params = {
             Namespace: namespace,
@@ -103,10 +103,13 @@ snapshot(config, function(err, details) {
             });
         }
 
-        cw.putMetricData(params, function(err) {
-            if (err) return log.error(err);
-            if (!details) return log.info('Snapshot failed, wrote error metric to %s', args.metric);
-            log.info('Wrote %s size / %s count metrics to %s', details.size, details.count, args.metric);
-        });
+        cwClient.send(new PutMetricDataCommand(params))
+            .then(() => {
+                if (!details) return log.info('Snapshot failed, wrote error metric to %s', args.metric);
+                log.info('Wrote %s size / %s count metrics to %s', details.size, details.count, args.metric);
+            })
+            .catch(err => {
+                log.error(err);
+            });
     }
 });

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var AWS = require('aws-sdk');
+var { S3Client, PutObjectCommand, DeleteObjectCommand } = require('@aws-sdk/client-s3');
 var Dyno = require('@mapbox/dyno');
 var queue = require('queue-async');
 var crypto = require('crypto');
@@ -118,16 +118,16 @@ function replicate(event, context, callback) {
 
 function incrementalBackup(event, context, callback) {
     var params = {
-        maxRetries: 1000,
-        httpOptions: {
-            timeout: 1000,
-            agent: module.exports.agent
+        maxAttempts: 1000,
+        requestHandler: {
+            connectionTimeout: 1000,
+            httpAgent: module.exports.agent
         }
     };
 
     if (process.env.BackupRegion) params.region = process.env.BackupRegion;
 
-    var s3 = new AWS.S3(params);
+    var s3Client = new S3Client(params);
 
     var filterer;
     if (process.env.TurnoverRole && process.env.TurnoverAt) {
@@ -185,28 +185,40 @@ function incrementalBackup(event, context, callback) {
                     Key: [process.env.BackupPrefix, table, id].join('/')
                 };
 
-                var req = change.eventName === 'REMOVE' ? 'deleteObject' : 'putObject';
-                if (req === 'putObject') params.Body = JSON.stringify(change.dynamodb.NewImage);
+                var command;
+                if (change.eventName === 'REMOVE') {
+                    command = new DeleteObjectCommand(params);
+                } else {
+                    params.Body = JSON.stringify(change.dynamodb.NewImage);
+                    command = new PutObjectCommand(params);
+                }
 
-                s3[req](params, function(err) {
-                    if (err) console.log(
-                        '[error] %s | %s s3://%s/%s | %s',
-                        JSON.stringify(change.dynamodb.Keys),
-                        req, params.Bucket, params.Key,
-                        err.message
-                    );
-                    next(err);
-                }).on('retry', function(res) {
-                    if (!res.error || !res.httpResponse || !res.httpResponse.headers) return;
-                    if (res.error.name === 'TimeoutError') res.error.retryable = true;
-                    console.log(
-                        '[failed-request] request-id: %s | id-2: %s | %s s3://%s/%s | %s',
-                        res.httpResponse.headers['x-amz-request-id'],
-                        res.httpResponse.headers['x-amz-id-2'],
-                        req, params.Bucket, params.Key,
-                        res.error
-                    );
-                });
+                s3Client.send(command)
+                    .then(() => {
+                        next();
+                    })
+                    .catch(err => {
+                        console.log(
+                            '[error] %s | %s s3://%s/%s | %s',
+                            JSON.stringify(change.dynamodb.Keys),
+                            change.eventName === 'REMOVE' ? 'deleteObject' : 'putObject',
+                            params.Bucket, params.Key,
+                            err.message
+                        );
+
+                        // Log retry information if available
+                        if (err.$metadata && err.$metadata.requestId) {
+                            console.log(
+                                '[failed-request] request-id: %s | %s s3://%s/%s | %s',
+                                err.$metadata.requestId,
+                                change.eventName === 'REMOVE' ? 'deleteObject' : 'putObject',
+                                params.Bucket, params.Key,
+                                err
+                            );
+                        }
+
+                        next(err);
+                    });
             });
         });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/dynamodb-replicator",
-  "version": "10.1.0",
+  "version": "11.0.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/dynamodb-replicator",
-      "version": "10.1.0",
+      "version": "11.0.0-beta.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.445.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,22 @@
 {
   "name": "@mapbox/dynamodb-replicator",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/dynamodb-replicator",
-      "version": "10.0.0",
+      "version": "10.1.0",
       "license": "ISC",
       "dependencies": {
+        "@aws-sdk/client-cloudwatch": "^3.445.0",
+        "@aws-sdk/client-dynamodb": "^3.445.0",
+        "@aws-sdk/client-s3": "^3.445.0",
+        "@aws-sdk/lib-storage": "^3.445.0",
+        "@aws-sdk/s3-request-presigner": "^3.848.0",
         "@mapbox/dyno": "^1.6.2",
         "@mapbox/s3scan": "^1.1.0",
         "agentkeepalive": "^4.5.0",
-        "aws-sdk": "^2.1476.0",
         "minimist": "^1.2.8",
         "queue-async": "1.0.7",
         "s3urls": "^1.5.2",
@@ -42,6 +46,1100 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.848.0.tgz",
+      "integrity": "sha512-eLB+R6uQcyHAGlWaCAYAUekcXqK4Kxwz3D2+OwOM+c1C3J56+tHs2bpFhDvsNolpecjCyYBri9JCVBRvs2nN9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/credential-provider-node": "3.848.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-compression": "^4.1.13",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-waiter": "^4.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.848.0.tgz",
+      "integrity": "sha512-sZSezrnvHmzsvWM7Yr5lu07tks5vzs156FwzT3u56KXgs7rd/BOrAuUeGLZ6qlxGuwMOyHnOM4GFalNzsIzbTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/credential-provider-node": "3.848.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.840.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-waiter": "^4.0.6",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.848.0.tgz",
+      "integrity": "sha512-6uT+THQfsB92eAH0p5zvpGiSCtO2ZhGwmuw6HWEngui53YIWz7W/GCnN0G7nrKpgD5DPrMaBwqZvKuoAh9NHAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/credential-provider-node": "3.848.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.840.0",
+        "@aws-sdk/middleware-expect-continue": "3.840.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.846.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-location-constraint": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-sdk-s3": "3.846.0",
+        "@aws-sdk/middleware-ssec": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/signature-v4-multi-region": "3.846.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
+        "@aws-sdk/xml-builder": "3.821.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/eventstream-serde-browser": "^4.0.4",
+        "@smithy/eventstream-serde-config-resolver": "^4.1.2",
+        "@smithy/eventstream-serde-node": "^4.0.4",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/hash-blob-browser": "^4.0.4",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/hash-stream-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/md5-js": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-stream": "^4.2.3",
+        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-waiter": "^4.0.6",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.848.0.tgz",
+      "integrity": "sha512-mD+gOwoeZQvbecVLGoCmY6pS7kg02BHesbtIxUj+PeBqYoZV5uLvjUOmuGfw1SfoSobKvS11urxC9S7zxU/Maw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.846.0.tgz",
+      "integrity": "sha512-7CX0pM906r4WSS68fCTNMTtBCSkTtf3Wggssmx13gD40gcWEZXsU00KzPp1bYheNRyPlAq3rE22xt4wLPXbuxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/xml-builder": "3.821.0",
+        "@smithy/core": "^3.7.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/signature-v4": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-utf8": "^4.0.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.846.0.tgz",
+      "integrity": "sha512-QuCQZET9enja7AWVISY+mpFrEIeHzvkx/JEEbHYzHhUkxcnC2Kq2c0bB7hDihGD0AZd3Xsm653hk1O97qu69zg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.846.0.tgz",
+      "integrity": "sha512-Jh1iKUuepdmtreMYozV2ePsPcOF5W9p3U4tWhi3v6nDvz0GsBjzjAROW+BW8XMz9vAD3I9R+8VC3/aq63p5nlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/node-http-handler": "^4.1.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-stream": "^4.2.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.848.0.tgz",
+      "integrity": "sha512-r6KWOG+En2xujuMhgZu7dzOZV3/M5U/5+PXrG8dLQ3rdPRB3vgp5tc56KMqLwm/EXKRzAOSuw/UE4HfNOAB8Hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/credential-provider-env": "3.846.0",
+        "@aws-sdk/credential-provider-http": "3.846.0",
+        "@aws-sdk/credential-provider-process": "3.846.0",
+        "@aws-sdk/credential-provider-sso": "3.848.0",
+        "@aws-sdk/credential-provider-web-identity": "3.848.0",
+        "@aws-sdk/nested-clients": "3.848.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/credential-provider-imds": "^4.0.6",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.848.0.tgz",
+      "integrity": "sha512-AblNesOqdzrfyASBCo1xW3uweiSro4Kft9/htdxLeCVU1KVOnFWA5P937MNahViRmIQm2sPBCqL8ZG0u9lnh5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.846.0",
+        "@aws-sdk/credential-provider-http": "3.846.0",
+        "@aws-sdk/credential-provider-ini": "3.848.0",
+        "@aws-sdk/credential-provider-process": "3.846.0",
+        "@aws-sdk/credential-provider-sso": "3.848.0",
+        "@aws-sdk/credential-provider-web-identity": "3.848.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/credential-provider-imds": "^4.0.6",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.846.0.tgz",
+      "integrity": "sha512-mEpwDYarJSH+CIXnnHN0QOe0MXI+HuPStD6gsv3z/7Q6ESl8KRWon3weFZCDnqpiJMUVavlDR0PPlAFg2MQoPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.848.0.tgz",
+      "integrity": "sha512-pozlDXOwJZL0e7w+dqXLgzVDB7oCx4WvtY0sk6l4i07uFliWF/exupb6pIehFWvTUcOvn5aFTTqcQaEzAD5Wsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.848.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/token-providers": "3.848.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.848.0.tgz",
+      "integrity": "sha512-D1fRpwPxtVDhcSc/D71exa2gYweV+ocp4D3brF0PgFd//JR3XahZ9W24rVnTQwYEcK9auiBZB89Ltv+WbWN8qw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/nested-clients": "3.848.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.804.0.tgz",
+      "integrity": "sha512-TQVDkA/lV6ua75ELZaichMzlp6x7tDa1bqdy/+0ZftmODPtKXuOOEcJxmdN7Ui/YRo1gkRz2D9txYy7IlNg1Og==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-storage": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.848.0.tgz",
+      "integrity": "sha512-Q23bI829ZQBHP6Iab9YsfCrZKvek2uMIVYEQjPa0Ekib5bmqURFCXhNtrP++TOCaZNr5DmSPAqAs8EGHWTOZiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/smithy-client": "^4.4.7",
+        "buffer": "5.6.0",
+        "events": "3.3.0",
+        "stream-browserify": "3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-s3": "^3.848.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-storage/node_modules/buffer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
+    "node_modules/@aws-sdk/lib-storage/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.840.0.tgz",
+      "integrity": "sha512-+gkQNtPwcSMmlwBHFd4saVVS11In6ID1HczNzpM3MXKXRBfSlbZJbCt6wN//AZ8HMklZEik4tcEOG0qa9UY8SQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-arn-parser": "3.804.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-config-provider": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.840.0.tgz",
+      "integrity": "sha512-IJDShY5NOg9luTE8h4o2Bm+gsPnHIU0tVWCjMz8vZMLevYjKdIsatcXiu3huTOjKSnelzC9fBHfU6KKsHmjjBQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "3.804.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.840.0.tgz",
+      "integrity": "sha512-iJg2r6FKsKKvdiU4oCOuCf7Ro/YE0Q2BT/QyEZN3/Rt8Nr4SAZiQOlcBXOCpGvuIKOEAhvDOUnW3aDHL01PdVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.846.0.tgz",
+      "integrity": "sha512-CdkeVfkwt3+bDLhmOwBxvkUf6oY9iUhvosaUnqkoPsOqIiUEN54yTGOnO8A0wLz6mMsZ6aBlfFrQhFnxt3c+yw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-stream": "^4.2.3",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.840.0.tgz",
+      "integrity": "sha512-ub+hXJAbAje94+Ya6c6eL7sYujoE8D4Bumu1NUI8TXjUhVVn0HzVWQjpRLshdLsUp1AW7XyeJaxyajRaJQ8+Xg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.840.0.tgz",
+      "integrity": "sha512-KVLD0u0YMF3aQkVF8bdyHAGWSUY6N1Du89htTLgqCcIhSxxAJ9qifrosVZ9jkAzqRW99hcufyt2LylcVU2yoKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.840.0.tgz",
+      "integrity": "sha512-lSV8FvjpdllpGaRspywss4CtXV8M7NNNH+2/j86vMH+YCOZ6fu2T/TyFd/tHwZ92vDfHctWkRbQxg0bagqwovA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.840.0.tgz",
+      "integrity": "sha512-Gu7lGDyfddyhIkj1Z1JtrY5NHb5+x/CRiB87GjaSrKxkDaydtX2CU977JIABtt69l9wLbcGDIQ+W0uJ5xPof7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.846.0.tgz",
+      "integrity": "sha512-jP9x+2Q87J5l8FOP+jlAd7vGLn0cC6G9QGmf386e5OslBPqxXKcl3RjqGLIOKKos2mVItY3ApP5xdXQx7jGTVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-arn-parser": "3.804.0",
+        "@smithy/core": "^3.7.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/signature-v4": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-stream": "^4.2.3",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.840.0.tgz",
+      "integrity": "sha512-CBZP9t1QbjDFGOrtnUEHL1oAvmnCUUm7p0aPNbIdSzNtH42TNKjPRN3TuEIJDGjkrqpL3MXyDSmNayDcw/XW7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.848.0.tgz",
+      "integrity": "sha512-rjMuqSWJEf169/ByxvBqfdei1iaduAnfolTshsZxwcmLIUtbYrFUmts0HrLQqsAG8feGPpDLHA272oPl+NTCCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
+        "@smithy/core": "^3.7.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.848.0.tgz",
+      "integrity": "sha512-joLsyyo9u61jnZuyYzo1z7kmS7VgWRAkzSGESVzQHfOA1H2PYeUFek6vLT4+c9xMGrX/Z6B0tkRdzfdOPiatLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.840.0.tgz",
+      "integrity": "sha512-Qjnxd/yDv9KpIMWr90ZDPtRj0v75AqGC92Lm9+oHXZ8p1MjG5JE2CW0HL8JRgK9iKzgKBL7pPQRXI8FkvEVfrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.848.0.tgz",
+      "integrity": "sha512-fm75L4M98UOPjFORyLdIgsPOuSXdbfpfOl3bNWcWFmeG8tDhqY+lGOyALYEZw/0O1MzEnyeK7wEGwAOf2PO5ZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "3.846.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-format-url": "3.840.0",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.846.0.tgz",
+      "integrity": "sha512-ZMfIMxUljqZzPJGOcraC6erwq/z1puNMU35cO1a/WdhB+LdYknMn1lr7SJuH754QwNzzIlZbEgg4hoHw50+DpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.846.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/signature-v4": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.848.0.tgz",
+      "integrity": "sha512-oNPyM4+Di2Umu0JJRFSxDcKQ35+Chl/rAwD47/bS0cDPI8yrao83mLXLeDqpRPHyQW4sXlP763FZcuAibC0+mg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/nested-clients": "3.848.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.840.0.tgz",
+      "integrity": "sha512-xliuHaUFZxEx1NSXeLLZ9Dyu6+EJVQKEoD+yM+zqUo3YDZ7medKJWY6fIOKiPX/N7XbLdBYwajb15Q7IL8KkeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.804.0.tgz",
+      "integrity": "sha512-wmBJqn1DRXnZu3b4EkE6CWnoWMo1ZMvlfkqU5zPz67xx1GMaXlDCchFvKAXMjk4jn/L1O3tKnoFDNsoLV1kgNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.848.0.tgz",
+      "integrity": "sha512-fY/NuFFCq/78liHvRyFKr+aqq1aA/uuVSANjzr5Ym8c+9Z3HRPE9OrExAHoMrZ6zC8tHerQwlsXYYH5XZ7H+ww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-endpoints": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.840.0.tgz",
+      "integrity": "sha512-VB1PWyI1TQPiPvg4w7tgUGGQER1xxXPNUqfh3baxUSFi1Oh8wHrDnFywkxLm3NMmgDmnLnSZ5Q326qAoyqKLSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/querystring-builder": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.804.0.tgz",
+      "integrity": "sha512-zVoRfpmBVPodYlnMjgVjfGoEZagyRF5IPn3Uo6ZvOZp24chnW/FRstH7ESDHDDRga4z3V+ElUQHKpFDXWyBW5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.840.0.tgz",
+      "integrity": "sha512-JdyZM3EhhL4PqwFpttZu1afDpPJCCc3eyZOLi+srpX11LsGj6sThf47TYQN75HT1CarZ7cCdQHGzP2uy3/xHfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/types": "^4.3.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.848.0.tgz",
+      "integrity": "sha512-Zz1ft9NiLqbzNj/M0jVNxaoxI2F4tGXN0ZbZIj+KJ+PbJo+w5+Jo6d0UDAtbj3AEd79pjcCaP4OA9NTVzItUdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.848.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.821.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.821.0.tgz",
+      "integrity": "sha512-DIIotRnefVL6DiaHtO6/21DhJ4JZnnIwdNbpwiAhdt/AVbttcE4yw925gsjur0OGv5BTYXQXU3YnANBYnZjuQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -318,20 +1416,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@mapbox/dynamodb-test/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@mapbox/dynamodb-test/node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -426,6 +1510,765 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.4.tgz",
+      "integrity": "sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.0.0.tgz",
+      "integrity": "sha512-+sKqDBQqb036hh4NPaUiEkYFkTUGYzRsn3EuFhyfQfMy6oGHEUJDurLP9Ufb5dasr/XiAmPNMr6wa9afjQB+Gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.0.0.tgz",
+      "integrity": "sha512-R9wM2yPmfEMsUmlMlIgSzOyICs0x9uu7UTHoccMyt7BWw8shcGM8HqB355+BZCPBcySvbTYMs62EgEQkNxz2ig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-base64": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.4.tgz",
+      "integrity": "sha512-prmU+rDddxHOH0oNcwemL+SwnzcG65sBF2yXRO7aeXIn/xTlq2pX7JLVbkBnVLowHLg4/OL4+jBmv9hVrVGS+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.7.1.tgz",
+      "integrity": "sha512-ExRCsHnXFtBPnM7MkfKBPcBBdHw1h/QS/cbNw4ho95qnyNHvnpmGbR39MIAv9KggTr5qSPxRSEL+hRXlyGyGQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-stream": "^4.2.3",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.6.tgz",
+      "integrity": "sha512-hKMWcANhUiNbCJouYkZ9V3+/Qf9pteR1dnwgdyzR09R4ODEYx8BbUysHwRSyex4rZ9zapddZhLFTnT4ZijR4pw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.4.tgz",
+      "integrity": "sha512-7XoWfZqWb/QoR/rAU4VSi0mWnO2vu9/ltS6JZ5ZSZv0eovLVfDfu0/AX4ub33RsJTOth3TiFWSHS5YdztvFnig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-hex-encoding": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.4.tgz",
+      "integrity": "sha512-3fb/9SYaYqbpy/z/H3yIi0bYKyAa89y6xPmIqwr2vQiUT2St+avRt8UKwsWt9fEdEasc5d/V+QjrviRaX1JRFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.1.2.tgz",
+      "integrity": "sha512-JGtambizrWP50xHgbzZI04IWU7LdI0nh/wGbqH3sJesYToMi2j/DcoElqyOcqEIG/D4tNyxgRuaqBXWE3zOFhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.4.tgz",
+      "integrity": "sha512-RD6UwNZ5zISpOWPuhVgRz60GkSIp0dy1fuZmj4RYmqLVRtejFqQ16WmfYDdoSoAjlp1LX+FnZo+/hkdmyyGZ1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.4.tgz",
+      "integrity": "sha512-UeJpOmLGhq1SLox79QWw/0n2PFX+oPRE1ZyRMxPIaFEfCqWaqpB7BU9C8kpPOGEhLF7AwEqfFbtwNxGy4ReENA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.0.tgz",
+      "integrity": "sha512-mADw7MS0bYe2OGKkHYMaqarOXuDwRbO6ArD91XhHcl2ynjGCFF+hvqf0LyQcYxkA1zaWjefSkU7Ne9mqgApSgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/querystring-builder": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-base64": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.0.4.tgz",
+      "integrity": "sha512-WszRiACJiQV3QG6XMV44i5YWlkrlsM5Yxgz4jvsksuu7LDXA6wAtypfPajtNTadzpJy3KyJPoWehYpmZGKUFIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^5.0.0",
+        "@smithy/chunked-blob-reader-native": "^4.0.0",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.4.tgz",
+      "integrity": "sha512-qnbTPUhCVnCgBp4z4BUJUhOEkVwxiEi1cyFM+Zj6o+aY8OFGxUQleKWq8ltgp3dujuhXojIvJWdoqpm6dVO3lQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.0.4.tgz",
+      "integrity": "sha512-wHo0d8GXyVmpmMh/qOR0R7Y46/G1y6OR8U+bSTB4ppEzRxd1xVAQ9xOE9hOc0bSjhz0ujCPAbfNLkLrpa6cevg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.4.tgz",
+      "integrity": "sha512-bNYMi7WKTJHu0gn26wg8OscncTt1t2b8KcsZxvOv56XA6cyXtOAAAaNP7+m45xfppXfOatXF3Sb1MNsLUgVLTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.0.4.tgz",
+      "integrity": "sha512-uGLBVqcOwrLvGh/v/jw423yWHq/ofUGK1W31M2TNspLQbUV1Va0F5kTxtirkoHawODAZcjXTSGi7JwbnPcDPJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-compression": {
+      "version": "4.1.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-compression/-/middleware-compression-4.1.14.tgz",
+      "integrity": "sha512-nUZcvILbAL+ZFPsrXpW1fkmTC559bHO1nO6OuGF5ktcClocwrMsAl5hkjDVpAihmIWCmrh5PzZSn5OTgGakTpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.7.1",
+        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-utf8": "^4.0.0",
+        "fflate": "0.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.4.tgz",
+      "integrity": "sha512-F7gDyfI2BB1Kc+4M6rpuOLne5LOcEknH1n6UQB69qv+HucXBR1rkzXBnQTB2q46sFy1PM/zuSJOB532yc8bg3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.16.tgz",
+      "integrity": "sha512-plpa50PIGLqzMR2ANKAw2yOW5YKS626KYKqae3atwucbz4Ve4uQ9K9BEZxDLIFmCu7hKLcrq2zmj4a+PfmUV5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.7.1",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-middleware": "^4.0.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.17.tgz",
+      "integrity": "sha512-gsCimeG6BApj0SBecwa1Be+Z+JOJe46iy3B3m3A8jKJHf7eIihP76Is4LwLrbJ1ygoS7Vg73lfqzejmLOrazUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/service-error-classification": "^4.0.6",
+        "@smithy/smithy-client": "^4.4.8",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.8.tgz",
+      "integrity": "sha512-iSSl7HJoJaGyMIoNn2B7czghOVwJ9nD7TMvLhMWeSB5vt0TnEYyRRqPJu/TqW76WScaNvYYB8nRoiBHR9S1Ddw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.4.tgz",
+      "integrity": "sha512-kagK5ggDrBUCCzI93ft6DjteNSfY8Ulr83UtySog/h09lTIOAJ/xUSObutanlPT0nhoHAkpmW9V5K8oPyLh+QA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.3.tgz",
+      "integrity": "sha512-HGHQr2s59qaU1lrVH6MbLlmOBxadtzTsoO4c+bF5asdgVik3I8o7JIOzoeqWc5MjVa+vD36/LWE0iXKpNqooRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.1.0.tgz",
+      "integrity": "sha512-vqfSiHz2v8b3TTTrdXi03vNz1KLYYS3bhHCDv36FYDqxT7jvTll1mMnCrkD+gOvgwybuunh/2VmvOMqwBegxEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/querystring-builder": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.4.tgz",
+      "integrity": "sha512-qHJ2sSgu4FqF4U/5UUp4DhXNmdTrgmoAai6oQiM+c5RZ/sbDwJ12qxB1M6FnP+Tn/ggkPZf9ccn4jqKSINaquw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.2.tgz",
+      "integrity": "sha512-rOG5cNLBXovxIrICSBm95dLqzfvxjEmuZx4KK3hWwPFHGdW3lxY0fZNXfv2zebfRO7sJZ5pKJYHScsqopeIWtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.4.tgz",
+      "integrity": "sha512-SwREZcDnEYoh9tLNgMbpop+UTGq44Hl9tdj3rf+yeLcfH7+J8OXEBaMc2kDxtyRHu8BhSg9ADEx0gFHvpJgU8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-uri-escape": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.4.tgz",
+      "integrity": "sha512-6yZf53i/qB8gRHH/l2ZwUG5xgkPgQF15/KxH0DdXMDHjesA9MeZje/853ifkSY0x4m5S+dfDZ+c4x439PF0M2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.6.tgz",
+      "integrity": "sha512-RRoTDL//7xi4tn5FrN2NzH17jbgmnKidUqd4KvquT0954/i6CXXkh1884jBiunq24g9cGtPBEXlU40W6EpNOOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.4.tgz",
+      "integrity": "sha512-63X0260LoFBjrHifPDs+nM9tV0VMkOTl4JRMYNuKh/f5PauSjowTfvF3LogfkWdcPoxsA9UjqEOgjeYIbhb7Nw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.2.tgz",
+      "integrity": "sha512-d3+U/VpX7a60seHziWnVZOHuEgJlclufjkS6zhXvxcJgkJq4UWdH5eOBLzHRMx6gXjsdT9h6lfpmLzbrdupHgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-hex-encoding": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-uri-escape": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.8.tgz",
+      "integrity": "sha512-pcW691/lx7V54gE+dDGC26nxz8nrvnvRSCJaIYD6XLPpOInEZeKdV/SpSux+wqeQ4Ine7LJQu8uxMvobTIBK0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.7.1",
+        "@smithy/middleware-endpoint": "^4.1.16",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-stream": "^4.2.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.1.tgz",
+      "integrity": "sha512-UqKOQBL2x6+HWl3P+3QqFD4ncKq0I8Nuz9QItGv5WuKuMHuuwlhvqcZCoXGfc+P1QmfJE7VieykoYYmrOoFJxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.4.tgz",
+      "integrity": "sha512-eMkc144MuN7B0TDA4U2fKs+BqczVbk3W+qIvcoCY6D1JY3hnAdCuhCZODC+GAeaxj0p6Jroz4+XMUn3PCxQQeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+      "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+      "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
+      "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
+      "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.24.tgz",
+      "integrity": "sha512-UkQNgaQ+bidw1MgdgPO1z1k95W/v8Ej/5o/T/Is8PiVUYPspl/ZxV6WO/8DrzZQu5ULnmpB9CDdMSRwgRc21AA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/smithy-client": "^4.4.8",
+        "@smithy/types": "^4.3.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.24.tgz",
+      "integrity": "sha512-phvGi/15Z4MpuQibTLOYIumvLdXb+XIJu8TA55voGgboln85jytA3wiD7CkUE8SNcWqkkb+uptZKPiuFouX/7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/credential-provider-imds": "^4.0.6",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/smithy-client": "^4.4.8",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.6.tgz",
+      "integrity": "sha512-YARl3tFL3WgPuLzljRUnrS2ngLiUtkwhQtj8PAL13XZSyUiNLQxwG3fBBq3QXFqGFUXepIN73pINp3y8c2nBmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+      "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.4.tgz",
+      "integrity": "sha512-9MLKmkBmf4PRb0ONJikCbCwORACcil6gUWojwARCClT7RmLzF04hUR4WdRprIXal7XVyrddadYNfp2eF3nrvtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.6.tgz",
+      "integrity": "sha512-+YekoF2CaSMv6zKrA6iI/N9yva3Gzn4L6n35Luydweu5MMPYpiGZlWqehPHDHyNbnyaYlz/WJyYAZnC+loBDZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.0.6",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.3.tgz",
+      "integrity": "sha512-cQn412DWHHFNKrQfbHY8vSFI3nTROY1aIKji9N0tpp8gUABRilr7wdf8fqBbSlXresobM+tQFNk6I+0LXK/YZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/node-http-handler": "^4.1.0",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-hex-encoding": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+      "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.0.6.tgz",
+      "integrity": "sha512-slcr1wdRbX7NFphXZOxtxRNA7hXAAtJAXJDE/wdoMAos27SIquVCKiSqfB6/28YzQ8FCsB5NKkhdM5gMADbqxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.10.0",
@@ -620,6 +2463,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -1254,6 +3103,24 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -1262,6 +3129,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.1.tgz",
+      "integrity": "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -2176,6 +4049,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
     "node_modules/mock-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/mock-property/-/mock-property-1.0.2.tgz",
@@ -2283,6 +4165,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -2462,6 +4350,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
@@ -2604,8 +4506,7 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
@@ -2698,6 +4599,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
     "node_modules/stream-combiner": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
@@ -2710,7 +4621,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -2771,6 +4681,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/subleveldown": {
       "version": "5.0.1",
@@ -2888,20 +4810,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/subleveldown/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2972,6 +4880,12 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3124,8 +5038,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
       "version": "8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/dynamodb-replicator",
-  "version": "11.0.0-beta.0",
+  "version": "11.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/dynamodb-replicator",
-      "version": "11.0.0-beta.0",
+      "version": "11.0.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.445.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@aws-sdk/lib-storage": "^3.445.0",
         "@aws-sdk/s3-request-presigner": "^3.848.0",
         "@mapbox/dyno": "^1.6.2",
-        "@mapbox/s3scan": "^1.1.0",
+        "@mapbox/s3scan": "^2.1.1",
         "agentkeepalive": "^4.5.0",
         "minimist": "^1.2.8",
         "queue-async": "1.0.7",
@@ -1457,14 +1457,15 @@
       }
     },
     "node_modules/@mapbox/s3scan": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/s3scan/-/s3scan-1.1.0.tgz",
-      "integrity": "sha512-Sm5bb424dN0WuBX60c0IKPP3ebYlfRIyncJjfmQ+buu3GuqleUgWJENGTsrfRXvJ+D1NAuAIvOddWxGEwL1BkQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/s3scan/-/s3scan-2.1.1.tgz",
+      "integrity": "sha512-k0T6nH0q6CrHFHFK1fmG4yoGuO4fyh+mhLcFs0/x7xRAasUTCJfC1VkVQtBFaIhPh0c5ArFN/VEjwpG//edMoA==",
+      "license": "ISC",
       "dependencies": {
-        "aws-sdk": "^2.49.0",
-        "minimist": "^1.2.0",
+        "@aws-sdk/client-s3": "^3.0.0",
+        "@smithy/node-http-handler": "^4.1.0",
+        "minimist": "^1.2.8",
         "parallel-stream": "^1.1.2",
-        "s3urls": "^1.5.2",
         "split": "^1.0.0"
       },
       "bin": {
@@ -1473,7 +1474,7 @@
         "s3scan": "bin/s3scan.js"
       },
       "engines": {
-        "node": "^6.0.0"
+        "node": "^18.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dynamodb-replicator",
-  "version": "11.0.0-beta.0",
+  "version": "11.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dynamodb-replicator",
-  "version": "10.1.0",
+  "version": "11.0.0-beta.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,12 +29,16 @@
   },
   "homepage": "https://github.com/mapbox/dynamodb-replicator",
   "dependencies": {
+    "@aws-sdk/client-cloudwatch": "^3.445.0",
+    "@aws-sdk/client-dynamodb": "^3.445.0",
+    "@aws-sdk/client-s3": "^3.445.0",
+    "@aws-sdk/lib-storage": "^3.445.0",
+    "@aws-sdk/s3-request-presigner": "^3.848.0",
     "@mapbox/dyno": "^1.6.2",
+    "@mapbox/s3scan": "^1.1.0",
     "agentkeepalive": "^4.5.0",
-    "aws-sdk": "^2.1476.0",
     "minimist": "^1.2.8",
     "queue-async": "1.0.7",
-    "@mapbox/s3scan": "^1.1.0",
     "s3urls": "^1.5.2",
     "underscore": "^1.13.6"
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@aws-sdk/lib-storage": "^3.445.0",
     "@aws-sdk/s3-request-presigner": "^3.848.0",
     "@mapbox/dyno": "^1.6.2",
-    "@mapbox/s3scan": "^1.1.0",
+    "@mapbox/s3scan": "^2.1.1",
     "agentkeepalive": "^4.5.0",
     "minimist": "^1.2.8",
     "queue-async": "1.0.7",

--- a/s3-backfill.js
+++ b/s3-backfill.js
@@ -1,5 +1,5 @@
 var Dyno = require('@mapbox/dyno');
-var AWS = require('aws-sdk');
+var { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
 var stream = require('stream');
 var queue = require('queue-async');
 var crypto = require('crypto');
@@ -14,11 +14,12 @@ module.exports.agent = new https.Agent({
 });
 
 function backfill(config, done) {
-    var s3 = new AWS.S3({
-        maxRetries: 1000,
-        httpOptions: {
-            timeout: 1000,
-            agent: module.exports.agent
+    var s3Client = new S3Client({
+        region: config.region,
+        maxAttempts: 1000,
+        requestHandler: {
+            connectionTimeout: 1000,
+            httpAgent: module.exports.agent
         }
     });
 
@@ -66,13 +67,18 @@ function backfill(config, done) {
             writer.drained = false;
             writer.pending++;
             writer.queue.defer(function(next) {
-                s3.putObject(params, function(err) {
-                    count++;
-                    process.stdout.write('\r\033[K' + count + ' - ' + (count / ((Date.now() - starttime) / 1000)).toFixed(2) + '/s');
-                    writer.pending--;
-                    if (err) writer.emit('error', err);
-                    next();
-                });
+                s3Client.send(new PutObjectCommand(params))
+                    .then(() => {
+                        count++;
+                        process.stdout.write('\r\033[K' + count + ' - ' + (count / ((Date.now() - starttime) / 1000)).toFixed(2) + '/s');
+                        writer.pending--;
+                    })
+                    .catch(err => {
+                        writer.emit('error', err);
+                        next();
+                    }).finally(() => {
+                        next();
+                    });
             });
             callback();
         };

--- a/s3-snapshot.js
+++ b/s3-snapshot.js
@@ -1,4 +1,5 @@
-var AWS = require('aws-sdk');
+var { S3Client } = require('@aws-sdk/client-s3');
+var { Upload } = require('@aws-sdk/lib-storage');
 var s3scan = require('@mapbox/s3scan');
 var zlib = require('zlib');
 var stream = require('stream');
@@ -14,25 +15,26 @@ module.exports = function(config, done) {
         return done(new Error('Must provide destination bucket and key where the snapshot will be put'));
 
     var s3Options = {
-        httpOptions: {
-            timeout: 1000,
-            agent: new AgentKeepAlive.HttpsAgent({
+        region: config.region || 'us-east-1',
+        requestHandler: {
+            connectionTimeout: 1000,
+            httpAgent: new AgentKeepAlive.HttpsAgent({
                 keepAlive: true,
                 maxSockets: 256,
-                keepAliveTimeout: 60000
+                keepAliveMsecs: 60000
             })
         }
     };
-    if (config.maxRetries) s3Options.maxRetries = config.maxRetries;
+    if (config.maxRetries) s3Options.maxAttempts = config.maxRetries;
     if (config.logger) s3Options.logger = config.logger;
 
-    var s3 = new AWS.S3(s3Options);
+    var s3Client = new S3Client(s3Options);
 
     var size = 0;
     var uri = ['s3:/', config.source.bucket, config.source.prefix].join('/');
     var partsLoaded = -1;
 
-    var objStream = s3scan.Scan(uri, { s3: s3 })
+    var objStream = s3scan.Scan(uri, { s3: s3Client })
         .on('error', function(err) { done(err); });
     var gzip = zlib.createGzip()
         .on('error', function(err) { done(err); });
@@ -44,11 +46,24 @@ module.exports = function(config, done) {
         callback(null, data.Body.toString() + '\n');
     };
 
-    var upload = s3.upload({
-        Bucket: config.destination.bucket,
-        Key: config.destination.key,
-        Body: gzip
-    }).on('httpUploadProgress', function(details) {
+    log(
+        'Starting snapshot from s3://%s/%s to s3://%s/%s',
+        config.source.bucket, config.source.prefix,
+        config.destination.bucket, config.destination.key
+    );
+
+    objStream.pipe(stringify).pipe(gzip);
+
+    const upload = new Upload({
+        client: s3Client,
+        params: {
+            Bucket: config.destination.bucket,
+            Key: config.destination.key,
+            Body: gzip
+        }
+    });
+
+    upload.on('httpUploadProgress', function(details) {
         if (details.part !== partsLoaded) {
             log(
                 'Starting upload of part #%s, %s bytes uploaded, %s items uploaded @ %s items/s',
@@ -59,21 +74,15 @@ module.exports = function(config, done) {
 
         partsLoaded = details.part;
         size = details.loaded;
-    }).on('error', function(err) { done(err); });
-
-    log(
-        'Starting snapshot from s3://%s/%s to s3://%s/%s',
-        config.source.bucket, config.source.prefix,
-        config.destination.bucket, config.destination.key
-    );
-
-    objStream.pipe(stringify).pipe(gzip);
-
-    upload.send(function(err) {
-        if (err) return done(err);
-
-        log('Uploaded snapshot to s3://%s/%s', config.destination.bucket, config.destination.key);
-        log('Wrote %s items and %s bytes to snapshot', objStream.got, size);
-        done(null, { size: size, count: objStream.got });
     });
+
+    upload.done()
+        .then(() => {
+            log('Uploaded snapshot to s3://%s/%s', config.destination.bucket, config.destination.key);
+            log('Wrote %s items and %s bytes to snapshot', objStream.got, size);
+            done(null, { size: size, count: objStream.got });
+        })
+        .catch(err => {
+            done(err);
+        });
 };

--- a/test/backup.test.js
+++ b/test/backup.test.js
@@ -3,8 +3,14 @@ var dynamodb = require('@mapbox/dynamodb-test')(test, 'dynamodb-replicator', req
 var backup = require('../backup');
 var _ = require('underscore');
 var crypto = require('crypto');
-var AWS = require('aws-sdk');
-var s3 = new AWS.S3();
+var { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3');
+var s3Client = new S3Client({
+    region: 'us-east-1',
+    credentials: {
+        accessKeyId: 'fake',
+        secretAccessKey: 'fake'
+    }
+});
 var queue = require('queue-async');
 var zlib = require('zlib');
 
@@ -45,13 +51,10 @@ dynamodb.test('backup: one segment', primaryItems, function(assert) {
         assert.equal(details.count, 3, 'reported 3 records');
         assert.equal(details.size, 101, 'reported 101 bytes');
 
-        s3.getObject({
+        s3Client.send(new GetObjectCommand({
             Bucket: 'mapbox',
             Key: [config.backup.prefix, config.backup.jobid, '0'].join('/')
-        }, function(err, data) {
-            assert.ifError(err, 'retrieved backup from S3');
-            if (err) return assert.end();
-
+        })).then(function(data) {
             assert.ok(data.Body, 'file has content');
 
             zlib.gunzip(data.Body, function(err, data) {
@@ -92,8 +95,16 @@ dynamodb.test('backup: parallel', records, function(assert) {
     queue(1)
         .defer(backup, firstConfig)
         .defer(backup, secondConfig)
-        .defer(s3.getObject.bind(s3), { Bucket: 'mapbox', Key: firstKey })
-        .defer(s3.getObject.bind(s3), { Bucket: 'mapbox', Key: secondKey })
+        .defer(function(cb) {
+            s3Client.send(new GetObjectCommand({ Bucket: 'mapbox', Key: firstKey }))
+                .then(data => cb(null, data))
+                .catch(err => cb(err));
+        })
+        .defer(function(cb) {
+            s3Client.send(new GetObjectCommand({ Bucket: 'mapbox', Key: secondKey }))
+                .then(data => cb(null, data))
+                .catch(err => cb(err));
+        })
         .awaitAll(function(err, results) {
             assert.ifError(err, 'all requests completed');
             if (err) return assert.end();

--- a/test/incremental.test.js
+++ b/test/incremental.test.js
@@ -1,6 +1,13 @@
 var test = require('tape');
-var AWS = require('aws-sdk');
-var s3 = new AWS.S3();
+var { S3Client, ListObjectsCommand, GetObjectCommand } = require('@aws-sdk/client-s3');
+var { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
+var s3Client = new S3Client({
+    region: 'us-east-1',
+    credentials: {
+        accessKeyId: 'fake',
+        secretAccessKey: 'fake'
+    }
+});
 var crypto = require('crypto');
 var tableDef = require('./fixtures/table');
 var dynamodb = require('@mapbox/dynamodb-test')(test, 's3-backfill', tableDef);
@@ -10,6 +17,7 @@ var zlib = require('zlib');
 var path = require('path');
 var os = require('os');
 var fs = require('fs');
+var https = require('https');
 
 var backfill = require('../s3-backfill');
 var snapshot = require('../s3-snapshot');
@@ -36,14 +44,15 @@ dynamodb.test('[s3-backfill]', records, function(assert) {
         console.log('\n');
         assert.ifError(err, 'success');
 
-        s3.listObjects({
+        s3Client.send(new ListObjectsCommand({
             Bucket: bucket,
             Prefix: prefix
-        }, function(err, data) {
-            if (err) throw err;
+        })).then(function(data) {
             checkS3(data.Contents.map(function(item) {
                 return item.Key;
             }));
+        }).catch(function(err) {
+            throw err;
         });
     });
 
@@ -61,13 +70,14 @@ dynamodb.test('[s3-backfill]', records, function(assert) {
 
             assert.ok(keys.indexOf(key) > -1, 'expected item written for ' + key);
             q.defer(function(next) {
-                s3.getObject({
+                s3Client.send(new GetObjectCommand({
                     Bucket: bucket,
                     Key: key
-                }, function(err, data) {
-                    if (err) throw err;
-                    assert.equal(data.Body.toString(), expected, 'expected data for ' + key);
+                })).then(function(data) {
+                    assert.equal(Buffer.from(data.Body).toString(), expected, 'expected data for ' + key);
                     next();
+                }).catch(function(err) {
+                    throw err;
                 });
             });
         });
@@ -109,10 +119,18 @@ test('[s3-snapshot]', function(assert) {
                 checkFile(result);
             });
 
-        s3.getObject({
+        // Get a signed URL for the S3 object
+        getSignedUrl(s3Client, new GetObjectCommand({
             Bucket: bucket,
             Key: snapshotKey
-        }).createReadStream().pipe(gunzip);
+        }), { expiresIn: 3600 }).then(function(url) {
+            // Use https to get the object and pipe it to gunzip
+            https.get(url, function(response) {
+                response.pipe(gunzip);
+            });
+        }).catch(function(err) {
+            throw err;
+        });
     });
 
     function checkFile(found) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,8 +10,14 @@ var replicate = require('..').replicate;
 var backup = require('..').backup;
 var _ = require('underscore');
 var crypto = require('crypto');
-var AWS = require('aws-sdk');
-var s3 = new AWS.S3();
+var { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3');
+var s3Client = new S3Client({
+    region: 'us-east-1',
+    credentials: {
+        accessKeyId: 'mock',
+        secretAccessKey: 'mock'
+    }
+});
 var queue = require('queue-async');
 
 replica.start();
@@ -138,14 +144,15 @@ test('[incremental backup] configurable region', function(assert) {
     process.env.BackupRegion = 'fake';
     assert.plan(2);
 
-    var S3 = AWS.S3;
-    AWS.S3 = function(config) {
+    var originalS3Client = S3Client;
+    S3Client = function(config) {
         assert.equal(config.region, 'fake', 'configured region on S3 client');
+        return new originalS3Client();
     };
 
     backup({ Records: [] }, {}, function(err) {
         assert.ifError(err, 'backup success');
-        AWS.S3 = S3;
+        S3Client = originalS3Client;
         delete process.env.BackupRegion;
     });
 });
@@ -162,16 +169,18 @@ test('[incremental backup] insert', function(assert) {
     backup(event, {}, function(err) {
         assert.ifError(err, 'success');
 
-        s3.getObject({
+        s3Client.send(new GetObjectCommand({
             Bucket: process.env.BackupBucket,
             Key: [process.env.BackupPrefix, table, id].join('/')
-        }, function(err, data) {
-            assert.ifError(err, 'no S3 error');
+        })).then(function(data) {
             assert.ok(data.Body, 'got S3 object');
 
-            var found = JSON.parse(data.Body.toString());
+            var found = JSON.parse(Buffer.from(data.Body).toString());
             var expected = { range: { N:'1' }, id: { S: 'record-1' } };
             assert.deepEqual(found, expected, 'expected item put to S3');
+            assert.end();
+        }).catch(function(err) {
+            assert.ifError(err, 'no S3 error');
             assert.end();
         });
     });
@@ -189,16 +198,18 @@ test('[incremental backup] insert & modify', function(assert) {
     backup(event, {}, function(err) {
         assert.ifError(err, 'success');
 
-        s3.getObject({
+        s3Client.send(new GetObjectCommand({
             Bucket: process.env.BackupBucket,
             Key: [process.env.BackupPrefix, table, id].join('/')
-        }, function(err, data) {
-            assert.ifError(err, 'no S3 error');
+        })).then(function(data) {
             assert.ok(data.Body, 'got S3 object');
 
-            var found = JSON.parse(data.Body.toString());
+            var found = JSON.parse(Buffer.from(data.Body).toString());
             var expected = { range: { N:'2' }, id: { S: 'record-1' } };
             assert.deepEqual(found, expected, 'expected item modified on S3');
+            assert.end();
+        }).catch(function(err) {
+            assert.ifError(err, 'no S3 error');
             assert.end();
         });
     });
@@ -216,11 +227,14 @@ test('[incremental backup] insert, modify & delete', function(assert) {
     backup(event, {}, function(err) {
         assert.ifError(err, 'success');
 
-        s3.getObject({
+        s3Client.send(new GetObjectCommand({
             Bucket: process.env.BackupBucket,
             Key: [process.env.BackupPrefix, table, id].join('/')
-        }, function(err) {
-            assert.equal(err.code, 'NoSuchKey', 'object was deleted');
+        })).then(function() {
+            assert.fail('Expected NoSuchKey error');
+            assert.end();
+        }).catch(function(err) {
+            assert.equal(err.name, 'NoSuchKey', 'object was deleted');
             assert.end();
         });
     });
@@ -248,16 +262,17 @@ test('[incremental backup] adjust many', function(assert) {
                     .update(JSON.stringify(key))
                     .digest('hex');
 
-                s3.getObject({
+                s3Client.send(new GetObjectCommand({
                     Bucket: process.env.BackupBucket,
                     Key: [process.env.BackupPrefix, table, id].join('/')
-                }, function(err, data) {
-                    assert.ifError(err, 'no S3 error for ' + JSON.stringify(key));
-                    if (!data) return next();
+                })).then(function(data) {
                     assert.ok(data.Body, 'got S3 object for ' + JSON.stringify(key));
 
-                    var found = JSON.parse(data.Body.toString());
+                    var found = JSON.parse(Buffer.from(data.Body).toString());
                     assert.deepEqual(found, record, 'expected item modified on S3 for ' + JSON.stringify(key));
+                    next();
+                }).catch(function(err) {
+                    assert.ifError(err, 'no S3 error for ' + JSON.stringify(key));
                     next();
                 });
             });
@@ -268,11 +283,14 @@ test('[incremental backup] adjust many', function(assert) {
                 .update(JSON.stringify({ id: { S: 'record-1' } }))
                 .digest('hex');
 
-            s3.getObject({
+            s3Client.send(new GetObjectCommand({
                 Bucket: process.env.BackupBucket,
                 Key: [process.env.BackupPrefix, table, id].join('/')
-            }, function(err) {
-                assert.equal(err.code, 'NoSuchKey', 'object was deleted');
+            })).then(function() {
+                assert.fail('Expected NoSuchKey error');
+                next();
+            }).catch(function(err) {
+                assert.equal(err.name, 'NoSuchKey', 'object was deleted');
                 next();
             });
         });

--- a/test/live-test.backup-table.js
+++ b/test/live-test.backup-table.js
@@ -3,7 +3,8 @@ var dynamodb = require('@mapbox/dynamodb-test')(test, 'dynamodb-replicator', req
 var exec = require('child_process').exec;
 var path = require('path');
 var crypto = require('crypto');
-var AWS = require('aws-sdk');
+var { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3');
+var { CloudWatchClient, GetMetricStatisticsCommand } = require('@aws-sdk/client-cloudwatch');
 var queue = require('queue-async');
 
 var primaryItems = [
@@ -31,25 +32,39 @@ dynamodb.test('backup-table shell script', primaryItems, function(assert) {
 
     exec(cmd, function(err) {
         assert.ifError(err, 'success');
-        var s3 = new AWS.S3();
-        var cw = new AWS.CloudWatch({ region: 'us-east-1' });
+        var s3Client = new S3Client({
+            region: 'us-east-1',
+            credentials: {
+                accessKeyId: 'fake',
+                secretAccessKey: 'fake'
+            }
+        });
+        var cwClient = new CloudWatchClient({
+            region: 'us-east-1',
+            credentials: {
+                accessKeyId: 'fake',
+                secretAccessKey: 'fake'
+            }
+        });
 
         console.log('Waiting 60s for CW to land...');
 
         setTimeout(function() {
             queue()
                 .defer(function(next) {
-                    s3.getObject({
+                    s3Client.send(new GetObjectCommand({
                         Bucket: 'mapbox',
                         Key: 'dynamodb-replicator/test/' + jobid + '/0'
-                    }, function(err, data) {
-                        assert.ifError(err, 'S3 getObject success');
+                    })).then(function(data) {
                         assert.ok(data.Body, 'Backup written to s3');
                         next();
+                    }).catch(function(err) {
+                        assert.ifError(err, 'S3 getObject success');
+                        next(err);
                     });
                 })
                 .defer(function(next) {
-                    cw.getMetricStatistics({
+                    cwClient.send(new GetMetricStatisticsCommand({
                         Namespace: 'Mapbox',
                         Dimensions: [
                             {
@@ -62,8 +77,7 @@ dynamodb.test('backup-table shell script', primaryItems, function(assert) {
                         EndTime: (new Date()).toISOString(),
                         Period: 60,
                         Statistics: ['Sum']
-                    }, function(err, data) {
-                        assert.ifError(err, 'CW BackupSize success');
+                    })).then(function(data) {
                         if (!data.Datapoints || !data.Datapoints.length) {
                             assert.fail('No CW data found');
                             return next();
@@ -71,10 +85,13 @@ dynamodb.test('backup-table shell script', primaryItems, function(assert) {
                         assert.equal(data.Datapoints.length, 1, 'BackupSize put to CW');
                         assert.equal(data.Datapoints[0].Sum, 101, 'Correct BackupSize value on CW');
                         next();
+                    }).catch(function(err) {
+                        assert.ifError(err, 'CW BackupSize success');
+                        next(err);
                     });
                 })
                 .defer(function(next) {
-                    cw.getMetricStatistics({
+                    cwClient.send(new GetMetricStatisticsCommand({
                         Namespace: 'Mapbox',
                         Dimensions: [
                             {
@@ -87,8 +104,7 @@ dynamodb.test('backup-table shell script', primaryItems, function(assert) {
                         EndTime: (new Date()).toISOString(),
                         Period: 60,
                         Statistics: ['Sum']
-                    }, function(err, data) {
-                        assert.ifError(err, 'CW BackupRecordCount success');
+                    })).then(function(data) {
                         if (!data.Datapoints || !data.Datapoints.length) {
                             assert.fail('No CW data found');
                             return next();
@@ -96,6 +112,9 @@ dynamodb.test('backup-table shell script', primaryItems, function(assert) {
                         assert.equal(data.Datapoints.length, 1, 'BackupRecordCount put to CW');
                         assert.equal(data.Datapoints[0].Sum, 3, 'Correct BackupRecordCount value on CW');
                         next();
+                    }).catch(function(err) {
+                        assert.ifError(err, 'CW BackupRecordCount success');
+                        next(err);
                     });
                 })
                 .await(function() {


### PR DESCRIPTION
## What Changed?
- Moved all aws-sdk v2 functions to aws-sdk v3

## Testing
### Current Setup
In [coredb-staging](https://eu-west-1.console.aws.amazon.com/dynamodbv2/home?region=eu-west-1#item-explorer?maximize=true&table=coredb-staging-cardboard) you can place an item.
I'll place a test item here in eu-west-1 (primary db table)
<img width="1129" height="722" alt="Screenshot 2025-07-21 at 2 16 01 PM" src="https://github.com/user-attachments/assets/a97c2426-5183-42ad-9a75-a18fdd841822" />

From there I can query and validate it exists in eu-west-1
<img width="670" height="233" alt="Screenshot 2025-07-21 at 2 20 46 PM" src="https://github.com/user-attachments/assets/9258ca46-0900-4192-b426-665544a71d53" />

Then, the coredb replicator runs and puts that record in us-west-2. I perform the same query in us-west-2 and observe:
<img width="1123" height="787" alt="Screenshot 2025-07-21 at 2 33 00 PM" src="https://github.com/user-attachments/assets/9e912a1c-0b4e-49f9-8654-96e9bb3a8e5d" />

So this works as a replicator, since global tables is not on.

### Testing with new changes
In this PR https://github.com/mapbox/coredb-replicator/pull/77 I upgrade the dynamodb replicator to use its beta state. This has been deployed to staging. Let's walk through the same workflow to make sure coredb-staging can handle the testing.

Create a new entry in eu-west-1:
<img width="913" height="854" alt="Screenshot 2025-07-21 at 2 44 04 PM" src="https://github.com/user-attachments/assets/bd459258-ec81-4a8a-aa9d-cd8938ab0df7" />

From there we can query to see if this has been replicated in us-west-2:
<img width="913" height="932" alt="Screenshot 2025-07-21 at 2 44 39 PM" src="https://github.com/user-attachments/assets/84cb48f1-7c89-41ad-aab8-18fc67c5e282" />

As you can see, this was replicated without any issue. The lambda sustained no errors in the process. This package is working as expected.