### PR TITLE
CLOUDPLAT-3162: add npm-release environment gate (dynamodb-replicator)

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -9,5 +9,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
+    environment: npm-release
     with:
       create-github-release: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dynamodb-replicator",
-  "version": "10.1.2",
+  "version": "10.1.3",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adding `environment: npm-release` to the npm release workflow.